### PR TITLE
Address Page | Add copy address button

### DIFF
--- a/src/components/AddressField.vue
+++ b/src/components/AddressField.vue
@@ -77,6 +77,7 @@ export default {
 <template lang="pug">
   div.inline-div
     q-icon( v-if="this.contract" class="far fa-file-alt q-pr-xs")
+      q-tooltip Contract
     //- router-link(:to="`/address/${this.address}`") {{ getDisplay() }}
     a(:href="`/address/${this.address}`") {{ getDisplay() }}
 </template>

--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -1,0 +1,76 @@
+<template>
+    <div class="c-copy-button">
+        <q-icon
+            :class="iconClasses"
+            :aria-label="hint"
+            aria-role="button"
+            tabindex="0"
+            @keydown.space.enter="handleClick"
+            @click="handleClick"
+        >
+            <q-tooltip>{{ hint }}</q-tooltip>
+        </q-icon>
+            
+
+    </div>
+</template>
+
+<script>
+const icons = {
+    copy: 'far fa-copy',
+    success: 'fas fa-check'
+};
+
+export default {
+    name: 'CopyButton',
+    props: {
+        text: {
+            type: String,
+            required: true,
+        },
+        description: {
+            type: String,
+            default: '',
+        },
+    },
+    data: () => ({
+        iconClass: icons.copy,
+        hint: ''
+    }),
+    computed: {
+        iconClasses() {
+            return `c-copy-button__icon ${this.iconClass} q-pa-sm`;
+        },
+        defaultHint() {
+            return `Copy ${this.description} to clipboard`;
+        }
+    },
+    created() {
+        this.hint = this.defaultHint;
+    },
+    methods: {
+        handleClick() {
+            navigator.clipboard.writeText(this.text);
+            this.iconClass = icons.success;
+            this.hint = "Copied";
+
+            setTimeout(() => {
+                this.iconClass = icons.copy;
+                this.hint = this.defaultHint;
+            }, 1500);
+        }
+    }
+}
+</script>
+
+<style lang="scss">
+.c-copy-button {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+
+    &__icon {
+        cursor: pointer;
+    }
+}
+</style>

--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -10,8 +10,6 @@
         >
             <q-tooltip>{{ hint }}</q-tooltip>
         </q-icon>
-            
-
     </div>
 </template>
 

--- a/src/pages/Address.vue
+++ b/src/pages/Address.vue
@@ -7,13 +7,21 @@ import ConfirmationDialog from "components/ConfirmationDialog";
 import ContractTab from 'components/ContractTab/ContractTab';
 import TransactionField from "components/TransactionField";
 import AddressField from "components/AddressField";
+import CopyButton from "components/CopyButton";
 
 const web3 = new Web3();
 export default {
   name: "Address",
   components: {
     AddressField,
-    TransactionField, TokenList, TransactionTable, TransferTable, ConfirmationDialog, ContractTab },
+    ConfirmationDialog,
+    ContractTab,
+    CopyButton,
+    TokenList,
+    TransactionField,
+    TransactionTable,
+    TransferTable,
+  },
   data() {
     return {
       address: this.$route.params.address,
@@ -100,6 +108,7 @@ export default {
           q-icon.cursor(v-if='isContract && isVerified !== null' :name="isVerified ? 'verified' : 'warning'" :class="isVerified ? 'text-green' : 'text-red'" size='1.25rem' @click='confirmationDialog = true')
           ConfirmationDialog(:flag='confirmationDialog' :address='address' :status="isVerified" @dialog='disableConfirmation')
           .text-white {{ address }}
+            CopyButton(:text="address" description="address")
           span(v-if='contract')
             .text-white Created at trx&nbsp
               TransactionField(:transaction-hash="contract.getCreationTrx()" )


### PR DESCRIPTION
Addresses #60 

In this PR:
- adds in a new component to handle text copy on click
- places copy text button on Address page
- adds in hover text for context on the existing `contract` icon (which indicates that a particular address is a smart contract) on the transactions table 

Testing notes:
- go to http://localhost:8081/address/0xfda16932cd56b9dcab6877df96c3a6bbc6cb33c0
- hover mouse over the little paper icon next to a name in the "To/Interacted With" column
    - text "Contract" should appear on hover
- click into an account, e.g. http://localhost:8081/address/0x3d2c6bced5f50f5412234b87ff0b445aba4d10e9
- without clicking on the page, paste into a text field (eg. address bar, blank document)
    - your clipboard contents should be whatever you last copied
- hover on the copy icon
    - text should appear "Copy address to clipboard"
    - you can also go into vue devtools -> `Address` -> `CopyButton`, edit the prop `description` to be blank, then upon hover, the icon should display a more generic message, "copy to clipboard"
- click the copy icon
    - you should see the icon and tooltip message change briefly to success state
- paste somewhere
    - you should see the account address pasted
