### PR TITLE
Bugfix | Fix handling of uint256[] contract args

### DIFF
--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -219,6 +219,7 @@ export default {
                 let param = this.abi.inputs[i];
                 formatted.push(this.formatValue(this.params[i], param.type));
             }
+
             return formatted;
         },
         formatValue(value, type) {
@@ -234,7 +235,7 @@ export default {
                 const arrayOfIntegersRegex = /^\[((\d+), ?)+(\d)+\]$/g
                 const paramsLength = type.match(uintArrayLengthRegex)[0];
 
-                const valueRepresentsAnArray = (value ?? '').test(arrayOfIntegersRegex);
+                const valueRepresentsAnArray = arrayOfIntegersRegex.test(value ?? '');
 
                 if (!valueRepresentsAnArray) {
                     const exampleArray = Array(paramsLength).fill('')


### PR DESCRIPTION
Addresses #102 

## Testing notes
- go to https://deploy-preview-103--testnet-teloscan.netlify.app/address/0xb13d91d5d76b75f3f66aa9b3dcb049bf5bfab97e/
- click Contract, Write, and scroll down to `_startLottery` 
- enter random integers for fields `_endTime`, `_priceTicketInTelos`, `_discountDivisor`, and `_treasuryFee`
- enter any array of ints, eg. `[1, 2, 3, 4, 5, 6]` to the field `_rewardsBreakdown`
    - method should fire and result in an error beginning with `Result (): cannot estimate gas` (indicating method was executed with correct data type but invalid values were passed
- try entering any other format, e.g. the incorrect number of args, `[1, 2, 3]` or `1, 2, 3` or `gewegdg34t324tgg`
    - method should fire and display an error beginning with `Result (): invalid value for array`
    - console error log should have informative message about formatting the argument properly