### PR TITLE
#171 | readwrite interface doesnt handle arrays properly

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -81,7 +81,7 @@ module.exports = function(/* ctx */) {
         devServer: {
             https: false,
             port: 8080,
-            open: true, // opens browser window automatically
+            open: false, // opens browser window automatically
         },
 
         // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-framework

--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -52,13 +52,7 @@
             </template>
         </q-input>
     </div>
-    <div
-        v-for="(param, idx) in abi.inputs"
-        :key="idx"
-        :class="{
-            'q-mb-md': !!getHintForInput(param.type),
-        }"
-    >
+    <div v-for="(param, idx) in abi.inputs" :key="idx">
         <q-input
             v-model="params[idx]"
             :label="makeLabel(param, idx)"

--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -327,8 +327,17 @@ export default {
             return contractInstance[this.getFunctionAbi()];
         },
         runRead() {
+            let params;
+
+            try {
+                params = this.getFormattedParams();
+            } catch (e) {
+                this.errorMessage = e;
+                return Promise.reject(e);
+            }
+
             return this.getEthersFunction()
-                .then(func => func(...this.getFormattedParams())
+                .then(func => func(...params)
                     .then(response => { this.result = response })
                     .catch((msg) => {
                         this.errorMessage = msg;

--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -118,7 +118,7 @@ import {
     parseAddressString,
     parseAddressArrayString,
     parseBooleanString,
-    parseBooleanArrayString,
+    parseBooleanArrayString, parameterTypeIsString,
 } from 'components/ContractTab/function-interface-utils';
 
 import TransactionField from 'components/TransactionField';
@@ -253,6 +253,8 @@ export default {
                 example = 'false';
             } else if (parameterTypeIsBooleanArray(type)) {
                 example = '[false, true]';
+            } else if (parameterTypeIsString(type)) {
+                example = 'Example string';
             }
 
             if (example)
@@ -270,6 +272,7 @@ export default {
             const typeIsAddressArray = parameterTypeIsAddressArray(type);
             const typeIsBoolean      = parameterTypeIsBoolean(type);
             const typeIsBooleanArray = parameterTypeIsBooleanArray(type);
+            const typeIsString       = parameterTypeIsString(type);
 
             let parsedValue;
 
@@ -285,6 +288,8 @@ export default {
                 parsedValue = parseBooleanString(value);
             }  else if (typeIsBooleanArray) {
                 parsedValue = parseBooleanArrayString(value, expectedArrayLength);
+            } else if (typeIsString) {
+                return value;
             } else {
                 return value;
             }

--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -113,12 +113,13 @@ import {
     parameterTypeIsAddressArray,
     parameterTypeIsBoolean,
     parameterTypeIsBooleanArray,
-    parseUint256FromString,
+    parseUint256String,
     parseUint256ArrayString,
     parseAddressString,
     parseAddressArrayString,
     parseBooleanString,
-    parseBooleanArrayString, parameterTypeIsString,
+    parseBooleanArrayString,
+    parameterTypeIsString,
 } from 'components/ContractTab/function-interface-utils';
 
 import TransactionField from 'components/TransactionField';
@@ -277,7 +278,7 @@ export default {
             let parsedValue;
 
             if (typeIsUint256) {
-                parsedValue = parseUint256FromString(value);
+                parsedValue = parseUint256String(value);
             } else if (typeIsUint256Array) {
                 parsedValue = parseUint256ArrayString(value, expectedArrayLength);
             } else if (typeIsAddress) {
@@ -336,6 +337,7 @@ export default {
 
             try {
                 params = this.getFormattedParams();
+                this.errorMessage = null;
             } catch (e) {
                 this.errorMessage = e;
                 return Promise.reject(e);
@@ -343,7 +345,10 @@ export default {
 
             return this.getEthersFunction()
                 .then(func => func(...params)
-                    .then(response => { this.result = response })
+                    .then(response => {
+                        this.result = response;
+                        this.errorMessage = null;
+                    })
                     .catch((msg) => {
                         this.errorMessage = msg;
                     })
@@ -417,6 +422,7 @@ export default {
             let params;
             try {
                 params = this.getFormattedParams();
+                this.errorMessage = null;
             } catch (e) {
                 this.errorMessage = e;
 
@@ -425,7 +431,6 @@ export default {
             const result = await func(...params, opts);
             this.hash = result.hash;
             this.endLoading();
-            this.errorMessage = null;
         },
         endLoading() {
             this.loading = false;

--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -264,7 +264,6 @@ export default {
             const value = rawValue.trim();
             const expectedArrayLength = getExpectedArrayLengthFromParameterType(type);
 
-
             const typeIsUint256      = parameterTypeIsUint256(type);
             const typeIsAddress      = parameterTypeIsAddress(type);
             const typeIsUint256Array = parameterTypeIsUint256Array(type);
@@ -291,8 +290,7 @@ export default {
             }
 
             if (parsedValue === undefined) {
-                // eztodo err handling & messaging
-                // return something
+                throw `Invalid value for type ${type}`;
             }
 
             return parsedValue;
@@ -401,9 +399,19 @@ export default {
         },
         async runEVM(opts) {
             const func = await this.getEthersFunction(this.$providerManager.getEthersProvider().getSigner());
-            const result = await func(...this.getFormattedParams(), opts);
+
+            let params;
+            try {
+                params = this.getFormattedParams();
+            } catch (e) {
+                this.errorMessage = e;
+
+                throw e;
+            }
+            const result = await func(...params, opts);
             this.hash = result.hash;
             this.endLoading();
+            this.errorMessage = null;
         },
         endLoading() {
             this.loading = false;

--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -251,20 +251,23 @@ export default {
             return type === 'uint256'
         },
         parameterTypeIsUint256Array(type) {
-            return /^uint256\[\d*]/g.test(type);
+            return /^uint256\[\d*]/.test(type);
         },
         parameterTypeIsAddress(type) {
             return type === 'address';
         },
         parameterTypeIsAddressArray(type) {
-            return /^address\[\d*]/g.test(type);
+            return /^address\[\d*]/.test(type);
+        },
+        parameterTypeIsBoolean(type) {
+            return type === 'bool';
         },
         getExpectedArrayLengthFromParameterType(type) {
-            const expectedArrayLengthRegex = /\d+(?=]$)/g;
+            const expectedArrayLengthRegex = /\d+(?=]$)/;
             return (+type.match(expectedArrayLengthRegex)?.[0]) || undefined;
         },
         parseUint256FromString(str = '') {
-            const uint256StringRegex = /^\d{1,256}$/g;
+            const uint256StringRegex = /^\d{1,256}$/;
             const stringRepresentsValidUint256 = uint256StringRegex.test(str);
 
             if (!stringRepresentsValidUint256) {
@@ -277,7 +280,7 @@ export default {
             if (str === '[]' && expectedLength === undefined)
                 return [];
 
-            const arrayOfUint256Regex = /^\[(\d{1,256}, *)*(\d{1,256})]$/g;
+            const arrayOfUint256Regex = /^\[(\d{1,256}, *)*(\d{1,256})]$/;
             const stringRepresentsValidUint256Array = arrayOfUint256Regex.test(str);
 
             if (!stringRepresentsValidUint256Array) {
@@ -306,7 +309,7 @@ export default {
             if (str === '[]' && expectedLength === undefined)
                 return [];
 
-            const arrayOfAddressRegex = /^\[((0x[a-zA-Z0-9]{40}, *)*(0x[a-zA-Z0-9]{40}))]$/g;
+            const arrayOfAddressRegex = /^\[((0x[a-zA-Z0-9]{40}, *)*(0x[a-zA-Z0-9]{40}))]$/;
             const stringRepresentsValidAddressArray = arrayOfAddressRegex.test(str);
 
             if (!stringRepresentsValidAddressArray) {
@@ -331,6 +334,18 @@ export default {
 
             return addressArray;
         },
+        parseBooleanString(str) {
+            const trueRegex  = /^true$/i;
+            const falseRegex = /^false$/i;
+
+            if (trueRegex.test(str))
+                return true;
+
+            if (falseRegex.test(str))
+                return false;
+
+            return undefined;
+        },
 
 
         formatValue(rawValue, type) {
@@ -341,6 +356,7 @@ export default {
             const typeIsAddress      = this.parameterTypeIsAddress(type);
             const typeIsUint256Array = this.parameterTypeIsUint256Array(type);
             const typeIsAddressArray = this.parameterTypeIsAddressArray(type);
+            const typeIsBoolean = this.parameterTypeIsBoolean(type);
 
             let parsedValue;
 
@@ -352,6 +368,8 @@ export default {
                 parsedValue = this.parseAddressString(value);
             } else if (typeIsAddressArray) {
                 parsedValue = this.parseAddressArrayString(value, expectedArrayLength);
+            } else if (typeIsBoolean) {
+                parsedValue = this.parseBooleanString(value);
             } else {
                 return value; //eztodo should this actually be done? or fail here. is it ever helpful to pass string along to contract fn?
             }

--- a/src/components/ContractTab/function-interface-utils.js
+++ b/src/components/ContractTab/function-interface-utils.js
@@ -6,7 +6,8 @@ export function parameterTypeIsImplemented(type) {
         parameterTypeIsAddress(type)      ||
         parameterTypeIsAddressArray(type) ||
         parameterTypeIsBoolean(type)      ||
-        parameterTypeIsBooleanArray(type);
+        parameterTypeIsBooleanArray(type) ||
+        parameterTypeIsString(type);
 }
 
 export function parameterTypeIsUint256(type) {
@@ -31,6 +32,10 @@ export function parameterTypeIsBoolean(type) {
 
 export function parameterTypeIsBooleanArray(type) {
     return /^bool\[\d*]/.test(type);
+}
+
+export function parameterTypeIsString(type) {
+    return type === 'string';
 }
 
 export function getExpectedArrayLengthFromParameterType(type) {

--- a/src/components/ContractTab/function-interface-utils.js
+++ b/src/components/ContractTab/function-interface-utils.js
@@ -1,0 +1,144 @@
+import { BigNumber, ethers } from 'ethers';
+
+export function parameterTypeIsImplemented(type) {
+    return parameterTypeIsUint256(type)   ||
+        parameterTypeIsUint256Array(type) ||
+        parameterTypeIsAddress(type)      ||
+        parameterTypeIsAddressArray(type) ||
+        parameterTypeIsBoolean(type)      ||
+        parameterTypeIsBooleanArray(type);
+}
+
+export function parameterTypeIsUint256(type) {
+    return type === 'uint256';
+}
+
+export function parameterTypeIsUint256Array(type) {
+    return /^uint256\[\d*]/.test(type);
+}
+
+export function parameterTypeIsAddress(type) {
+    return type === 'address';
+}
+
+export function parameterTypeIsAddressArray(type) {
+    return /^address\[\d*]/.test(type);
+}
+
+export function parameterTypeIsBoolean(type) {
+    return type === 'bool';
+}
+
+export function parameterTypeIsBooleanArray(type) {
+    return /^bool\[\d*]/.test(type);
+}
+
+export function getExpectedArrayLengthFromParameterType(type) {
+    const expectedArrayLengthRegex = /\d+(?=]$)/;
+    return (+type.match(expectedArrayLengthRegex)?.[0]) || undefined;
+}
+
+export function parseUint256FromString(str = '') {
+    const uint256StringRegex = /^\d{1,256}$/;
+    const stringRepresentsValidUint256 = uint256StringRegex.test(str);
+
+    if (!stringRepresentsValidUint256) {
+        return undefined;
+    }
+
+    return BigNumber.from(str);
+}
+
+export function parseUint256ArrayString(str = '', expectedLength) {
+    if (str === '[]' && expectedLength === undefined)
+        return [];
+
+    const arrayOfUint256Regex = /^\[(\d{1,256} *)*(\d{1,256})]$/;
+    const stringRepresentsValidUint256Array = arrayOfUint256Regex.test(str);
+
+    if (!stringRepresentsValidUint256Array)
+        return undefined;
+
+    const bigNumberArray = str.match(/\d+/g).map(intString => BigNumber.from(intString))
+
+    if (Number.isInteger(expectedLength)) {
+        const actualLength = bigNumberArray.length;
+
+        if (actualLength !== expectedLength)
+            return undefined;
+    }
+
+    return bigNumberArray;
+}
+
+export function parseAddressString(str) {
+    try {
+        return ethers.utils.getAddress(str);
+    } catch {
+        return undefined;
+    }
+}
+
+export function parseAddressArrayString(str, expectedLength) {
+    if (str === '[]' && expectedLength === undefined)
+        return [];
+
+    const arrayOfAddressRegex = /^\[((0x[a-zA-Z0-9]{40} *)*(0x[a-zA-Z0-9]{40}))]$/;
+    const stringRepresentsValidAddressArray = arrayOfAddressRegex.test(str);
+
+    if (!stringRepresentsValidAddressArray)
+        return undefined;
+
+    let addressArray;
+
+    try {
+        const addressStringArray = str.match(/0x[a-zA-Z0-9]{40}/g);
+        addressArray = addressStringArray.map(addressString => ethers.utils.getAddress(addressString));
+    } catch {
+        return undefined;
+    }
+
+    if (Number.isInteger(expectedLength)) {
+        const actualLength = addressArray.length;
+
+        if (actualLength !== expectedLength)
+            return undefined;
+    }
+
+    return addressArray;
+}
+
+export function parseBooleanString(str) {
+    const trueRegex  = /^true$/i;
+    const falseRegex = /^false$/i;
+
+    if (trueRegex.test(str))
+        return true;
+
+    if (falseRegex.test(str))
+        return false;
+
+    return undefined;
+}
+
+export function parseBooleanArrayString(str, expectedLength) {
+
+    const booleanArrayStringRegex = /^\[((true|false), *)*(true|false)]$/i;
+
+    const stringRepresentValidBoolArray = booleanArrayStringRegex.test(str);
+    if (!stringRepresentValidBoolArray)
+        return undefined;
+
+    const booleanRegex = /true|false/gi;
+    const trueRegex = /true/i;
+    const boolArray = str.match(booleanRegex).map(bool => trueRegex.test(bool));
+
+    if (Number.isInteger(expectedLength)) {
+        const actualLength = boolArray.length;
+
+        if (actualLength !== expectedLength)
+            return undefined;
+    }
+
+    return boolArray;
+}

--- a/src/components/ContractTab/function-interface-utils.js
+++ b/src/components/ContractTab/function-interface-utils.js
@@ -1,6 +1,6 @@
 import { BigNumber, ethers } from 'ethers';
 
-export function parameterTypeIsImplemented(type) {
+function parameterTypeIsImplemented(type) {
     return parameterTypeIsUint256(type)   ||
         parameterTypeIsUint256Array(type) ||
         parameterTypeIsAddress(type)      ||
@@ -10,40 +10,40 @@ export function parameterTypeIsImplemented(type) {
         parameterTypeIsString(type);
 }
 
-export function parameterTypeIsUint256(type) {
+function parameterTypeIsUint256(type) {
     return type === 'uint256';
 }
 
-export function parameterTypeIsUint256Array(type) {
+function parameterTypeIsUint256Array(type) {
     return /^uint256\[\d*]/.test(type);
 }
 
-export function parameterTypeIsAddress(type) {
+function parameterTypeIsAddress(type) {
     return type === 'address';
 }
 
-export function parameterTypeIsAddressArray(type) {
+function parameterTypeIsAddressArray(type) {
     return /^address\[\d*]/.test(type);
 }
 
-export function parameterTypeIsBoolean(type) {
+function parameterTypeIsBoolean(type) {
     return type === 'bool';
 }
 
-export function parameterTypeIsBooleanArray(type) {
+function parameterTypeIsBooleanArray(type) {
     return /^bool\[\d*]/.test(type);
 }
 
-export function parameterTypeIsString(type) {
+function parameterTypeIsString(type) {
     return type === 'string';
 }
 
-export function getExpectedArrayLengthFromParameterType(type) {
+function getExpectedArrayLengthFromParameterType(type) {
     const expectedArrayLengthRegex = /\d+(?=]$)/;
     return (+type.match(expectedArrayLengthRegex)?.[0]) || undefined;
 }
 
-export function parseUint256FromString(str = '') {
+function parseUint256String(str = '') {
     const uint256StringRegex = /^\d{1,256}$/;
     const stringRepresentsValidUint256 = uint256StringRegex.test(str);
 
@@ -54,17 +54,17 @@ export function parseUint256FromString(str = '') {
     return BigNumber.from(str);
 }
 
-export function parseUint256ArrayString(str = '', expectedLength) {
+function parseUint256ArrayString(str = '', expectedLength) {
     if (str === '[]' && expectedLength === undefined)
         return [];
 
-    const arrayOfUint256Regex = /^\[(\d{1,256} *)*(\d{1,256})]$/;
+    const arrayOfUint256Regex = /^\[(\d{1,256}, *)*(\d{1,256})]$/;
     const stringRepresentsValidUint256Array = arrayOfUint256Regex.test(str);
 
     if (!stringRepresentsValidUint256Array)
         return undefined;
 
-    const bigNumberArray = str.match(/\d+/g).map(intString => BigNumber.from(intString))
+    const bigNumberArray = str.match(/\d+/g).map(intString => BigNumber.from(intString));
 
     if (Number.isInteger(expectedLength)) {
         const actualLength = bigNumberArray.length;
@@ -76,7 +76,7 @@ export function parseUint256ArrayString(str = '', expectedLength) {
     return bigNumberArray;
 }
 
-export function parseAddressString(str) {
+function parseAddressString(str) {
     try {
         return ethers.utils.getAddress(str);
     } catch {
@@ -84,11 +84,11 @@ export function parseAddressString(str) {
     }
 }
 
-export function parseAddressArrayString(str, expectedLength) {
+function parseAddressArrayString(str, expectedLength) {
     if (str === '[]' && expectedLength === undefined)
         return [];
 
-    const arrayOfAddressRegex = /^\[((0x[a-zA-Z0-9]{40} *)*(0x[a-zA-Z0-9]{40}))]$/;
+    const arrayOfAddressRegex = /^\[((0x[a-zA-Z0-9]{40}, *)*(0x[a-zA-Z0-9]{40}))]$/;
     const stringRepresentsValidAddressArray = arrayOfAddressRegex.test(str);
 
     if (!stringRepresentsValidAddressArray)
@@ -113,7 +113,7 @@ export function parseAddressArrayString(str, expectedLength) {
     return addressArray;
 }
 
-export function parseBooleanString(str) {
+function parseBooleanString(str) {
     const trueRegex  = /^true$/i;
     const falseRegex = /^false$/i;
 
@@ -126,7 +126,9 @@ export function parseBooleanString(str) {
     return undefined;
 }
 
-export function parseBooleanArrayString(str, expectedLength) {
+function parseBooleanArrayString(str, expectedLength) {
+    if (str === '[]' && expectedLength === undefined)
+        return [];
 
     const booleanArrayStringRegex = /^\[((true|false), *)*(true|false)]$/i;
 
@@ -146,4 +148,23 @@ export function parseBooleanArrayString(str, expectedLength) {
     }
 
     return boolArray;
+}
+
+
+export {
+    parameterTypeIsImplemented,
+    parameterTypeIsUint256,
+    parameterTypeIsUint256Array,
+    parameterTypeIsAddress,
+    parameterTypeIsAddressArray,
+    parameterTypeIsBoolean,
+    parameterTypeIsBooleanArray,
+    parameterTypeIsString,
+    getExpectedArrayLengthFromParameterType,
+    parseUint256String,
+    parseUint256ArrayString,
+    parseAddressString,
+    parseAddressArrayString,
+    parseBooleanString,
+    parseBooleanArrayString,
 }


### PR DESCRIPTION
# Fixes #171

## Description

This PR adds in some functionality as a stopgap until function interfaces are overhauled in #104. Currently, several types of ABI function types are not parsed correctly, leading to errors (see Issue for more info)
- adds support for `address`, `address[n?]`, `bool`,  `bool[n?]` , and `string`
- adds support for fixed vs unbounded arrays for above types as well as `uint256`, eg. `uint256[3]` is not equivalent to `uint256`
- adds warning for inputs corresponding to unimplemented types, so the user is aware of current limitations
- adds rudimentary error message & prevents method execution if supported input type has invalid value
- adds hint (in the form of placeholder text) indicating what a correct value should look like

## Test scenarios

- run `yarn dev`
- copy this mock ABI, created to test each type of validated input
    ```json
    [{"inputs":[{"internalType":"string","name":"fakeStringField","type":"string"}],"name":"fakeWriteMethodWithString","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"string","name":"fakeStringField","type":"string"}],"name":"fakeReadMethodWithString","outputs":[],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"fakeAddressField","type":"address"}],"name":"fakeReadMethodWithAddress","outputs":[],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address[]","name":"fakeUnboundedAddressArrayField","type":"address[]"}],"name":"fakeReadMethodWithUnboundedAddressArray","outputs":[],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address[2]","name":"fakeFixedSizeAddressArrayField","type":"address[2]"}],"name":"fakeReadMethodWithFixedSizeAddressArray","outputs":[],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bool","name":"fakeBoolField","type":"bool"}],"name":"fakeReadMethodWithBool","outputs":[],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bool[]","name":"fakeUnboundedBoolArrayField","type":"bool[]"}],"name":"fakeReadMethodWithUnboundedBoolArray","outputs":[],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bool[3]","name":"fakeFixedSizeBoolArrayField","type":"bool[3]"}],"name":"fakeReadMethodWithFixedSizeBoolArray","outputs":[],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"fakeUint256Field","type":"uint256"}],"name":"fakeReadMethodWithUint256","outputs":[],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256[]","name":"fakeUnboundedUint256ArrayField","type":"uint256[]"}],"name":"fakeReadMethodWithUnboundedUint256Array","outputs":[],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256[3]","name":"fakeFixedSizeUint256ArrayField","type":"uint256[3]"}],"name":"fakeReadMethodWithFixedSizeUint256Array","outputs":[],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"fakeBytes32Field","type":"bytes32"}],"name":"fakeReadMethodWithBytes32","outputs":[],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint8[3]","name":"fakeFixedSizeUint8ArrayField","type":"uint8[3]"}],"name":"fakeReadMethodWithFixedSizeUint256Array","outputs":[],"stateMutability":"view","type":"function"}]
    ```
- go to any unvalidated contract address page, eg. http://192.168.236.164:8080/address/0x6ac4c48f04dd498dae1e043da096583c4d4719b3#contract
- click the "ABI from JSON" tab
- paste the mock ABI from above
    - read and write tabs should appear below the ABI field
- for each input in each tab, note the following:
    - the input, if implemented, should display a hint placeholder text when focused, guiding the user as to what a correct value would look like
    - entering any invalid value (including an array of the wrong length for bounded arrays) should result in an error message
    - entering a valid value and executing the method should clear the error message
    - for array types, entering any number of spaces after a comma should not produce an error, eg `[1, 2,      3,4]`
    - if an input is not valid, it should display a warning 




