### PR TITLE
#67 | Fix TX page date field width

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Telos EVM Explorer
 
-Main Net: [![Netlify Status](https://api.netlify.com/api/v1/badges/1a750b68-90d9-4e80-8ac9-74084bc475ae/deploy-status)](https://app.netlify.com/sites/teloscan/deploys) [https://www.teloscan.io/](https://www.teloscan.io/)  
+Main Net: [![Netlify Status](https://api.netlify.com/api/v1/badges/1a750b68-90d9-4e80-8ac9-74084bc475ae/deploy-status)](https://app.netlify.com/sites/teloscan/deploys) [teloscan.io](https://www.teloscan.io/)  
 
-Test Net: [![Netlify Status](https://api.netlify.com/api/v1/badges/21a714ec-2847-458f-880e-67ffaf31b89a/deploy-status)](https://app.netlify.com/sites/testnet-teloscan/deploys) [https://testnet.teloscan.io/](https://testnet.teloscan.io/)
+Test Net: [![Netlify Status](https://api.netlify.com/api/v1/badges/21a714ec-2847-458f-880e-67ffaf31b89a/deploy-status)](https://app.netlify.com/sites/testnet-teloscan/deploys) [testnet.teloscan.io](https://testnet.teloscan.io/)
 
 ## Install the dependencies
 
 ### Install yarn package manager
-Follow the installation instructions at:
-https://classic.yarnpkg.com/en/
+Follow the installation instructions at [classic.yarnpkg.com](https://classic.yarnpkg.com/en/)
+
 
 ### Add Vue and Quasar packages
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ yarn lint
 yarn build
 ```
 
-### Customize the configuration
-See [Configuring quasar.conf.js](https://quasar.dev/quasar-cli/quasar-conf-js).
+## Documentation
+Telos - [docs.telos.net](https://docs.telos.net)
 
-### More Information
-See  [https://quasar.dev](https://quasar.dev/).
+Quasar - [quasar.dev](https://quasar.dev/)
+
+Quasar Configuration - [quasar.conf.js](https://quasar.dev/quasar-cli/quasar-conf-js)

--- a/src/components/DateField.vue
+++ b/src/components/DateField.vue
@@ -25,5 +25,12 @@ export default {
 </script>
 
 <template lang="pug">
-div {{ friendlyDate }}
+div.c-date-field {{ friendlyDate }}
 </template>
+
+<style lang="scss">
+.c-date-field {
+    cursor: pointer;
+    max-width: max-content;
+}
+</style>

--- a/src/pages/Transaction.vue
+++ b/src/pages/Transaction.vue
@@ -261,10 +261,10 @@ export default {
             div( @click="showAge = !showAge" class="fit row wrap justify-start items-start content-start date")
                 div(class="col-3"  )
                   strong {{ `Date: ` }}
-                div.col-9
-                  q-icon(class="far fa-clock q-pr-xs q-pb-xs")
-                  date-field( :epoch="trx.epoch" :show-age="showAge" style="cursor: pointer;" )
-                q-tooltip Click to change date format
+                div.u-flex--left
+                  q-icon(class="far fa-clock q-mr-xs")
+                  date-field( :epoch="trx.epoch" :show-age="showAge" )
+                  q-tooltip Click to change date format
             br
             div(class="fit row wrap justify-start items-start content-start")
               div(class="col-3")


### PR DESCRIPTION
# Fixes #67 

## Description

The date field presently overflows on the transaction page, causing whitespace to trigger the tooltip & allow toggling of the date field format

## Test scenarios
- run `yarn dev`
- go to any transaction page, eg. http://localhost:8080/tx/0xfc37ae7c127c0cf6550d62cef7e06f06f5c020f191fcb38c8d353473e1e4448f
- hover your cursor over the date field
    - a tooltip should appear
- click the date field
    - the format of the date should change
- hover to the right of the date field
    - no tool tip should appear
- click to the right of the date field
    - the date format should not change

