### PR TITLE
#202 | Fix MetaMask login for mobile clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@eosrio/hyperion-stream-client": "^0.4.0-beta.5",
     "@ethereumjs/tx": "^3.5.0",
+    "@metamask/detect-provider": "^2.0.0",
     "@quasar/extras": "^1.0.0",
     "@telosnetwork/telosevm-js": "^0.2.6",
     "axios": "^0.21.2",

--- a/src/boot/api.js
+++ b/src/boot/api.js
@@ -65,4 +65,6 @@ export default boot(async ({ store }) => {
         getAccount: getAccount.bind(store),
         getRpc: getRpc.bind(store),
     };
+
+    store.dispatch('general/fetchBrowserEthereumSupport');
 });

--- a/src/components/ConnectButton.vue
+++ b/src/components/ConnectButton.vue
@@ -2,6 +2,7 @@
 import MetamaskLogo from 'src/assets/metamask-fox.svg'
 import { mapGetters, mapMutations } from 'vuex';
 import { ethers } from 'ethers';
+
 const providersError = 'More than one provider is active, disable additional providers.';
 const unsupportedError ='current EVM wallet provider is not supported.';
 const LOGIN_EVM = 'evm';
@@ -216,34 +217,59 @@ export default {
 }
 </script>
 
-<template lang='pug'>
-div()
-    q-btn( v-if='!isLoggedIn' id='c-connect-button__login-button' label='Connect Wallet' @click='connect()' )
-    q-btn-dropdown( v-if='isLoggedIn' :label='getLoginDisplay()' )
-      q-list()
-        q-item( clickable v-close-popup @click='goToAddress()' )
-          q-item-section()
-            q-item-label() View address
-        q-item( clickable v-close-popup @click='disconnect()' )
-          q-item-section()
-            q-item-label() Disconnect
-    q-dialog( v-model='showLogin' )
-      q-card( rounded )
-        q-tabs( v-model='tab' )
-          q-tab( name='web3' label='EVM Wallets' )
-          q-tab( name='native' label='Native Wallets' )
-        q-separator()
-        q-tab-panels( v-model='tab' animated )
-          q-tab-panel( name='web3' )
-            q-card.wallet-icon.cursor-pointer( @click='injectedWeb3Login()' )
-              q-img.wallet-img( :src='metamaskLogo' )
-              p Metamask
-          q-tab-panel( name='native' )
-            q-card.wallet-icon.cursor-pointer( v-for='(wallet, idx) in $ual.authenticators'
-              :key='wallet.getStyle().text'
-              @click='ualLogin(wallet)' )
-              q-img.wallet-img( :src='wallet.getStyle().icon' )
-              p {{ wallet.getStyle().text }}
+<template>
+<div class="c-connect-button">
+    <q-btn
+        v-if="!isLoggedIn"
+        id="c-connect-button__login-button"
+        label="Connect Wallet"
+        @click="connect"
+    />
+
+    <q-btn-dropdown v-else :label="getLoginDisplay()">
+        <q-list>
+            <q-item clickable="clickable" v-close-popup @click="goToAddress()">
+                <q-item-section>
+                    <q-item-label>View address</q-item-label>
+                </q-item-section>
+            </q-item>
+            <q-item clickable="clickable" v-close-popup @click="disconnect()">
+                <q-item-section>
+                    <q-item-label>Disconnect</q-item-label>
+                </q-item-section>
+            </q-item>
+        </q-list>
+    </q-btn-dropdown>
+
+    <q-dialog v-model="showLogin">
+        <q-card rounded="rounded">
+            <q-tabs v-model="tab">
+                <q-tab name="web3" label="EVM Wallets"></q-tab>
+                <q-tab name="native" label="Native Wallets"></q-tab>
+            </q-tabs>
+            <q-separator/>
+            <q-tab-panels v-model="tab" animated="animated">
+                <q-tab-panel name="web3">
+                    <q-card class="wallet-icon cursor-pointer" @click="injectedWeb3Login()">
+                        <q-img class="wallet-img" :src="metamaskLogo"></q-img>
+                        <p>Metamask</p>
+                    </q-card>
+                </q-tab-panel>
+                <q-tab-panel name="native">
+                    <q-card
+                        class="wallet-icon cursor-pointer"
+                        v-for="wallet in $ual.authenticators"
+                        :key="wallet.getStyle().text"
+                        @click="ualLogin(wallet)"
+                    >
+                        <q-img class="wallet-img" :src="wallet.getStyle().icon"></q-img>
+                        <p>{{ wallet.getStyle().text }}</p>
+                    </q-card>
+                </q-tab-panel>
+            </q-tab-panels>
+        </q-card>
+    </q-dialog>
+</div>
 </template>
 
 <style lang='sass'>

--- a/src/components/ConnectButton.vue
+++ b/src/components/ConnectButton.vue
@@ -1,6 +1,6 @@
 <script>
 import MetamaskLogo from 'src/assets/metamask-fox.svg'
-import { mapGetters, mapMutations } from 'vuex';
+import { mapGetters, mapMutations, mapState } from 'vuex';
 import { ethers } from 'ethers';
 
 const providersError = 'More than one provider is active, disable additional providers.';
@@ -27,6 +27,7 @@ export default {
             'address',
             'nativeAccount',
         ]),
+        ...mapState('general', ['browserSupportsEthereum']),
     },
     async mounted() {
         const loginData = localStorage.getItem('loginData');
@@ -82,6 +83,11 @@ export default {
             this.$router.push(`/address/${this.address}`);
         },
         async injectedWeb3Login() {
+            if (!this.browserSupportsEthereum) {
+                window.open('https://metamask.app.link/dapp/teloscan.io');
+                return;
+            }
+
             const address = await this.getInjectedAddress();
             if (address) {
                 this.setLogin({
@@ -252,7 +258,7 @@ export default {
                 <q-tab-panel name="web3">
                     <q-card class="wallet-icon cursor-pointer" @click="injectedWeb3Login()">
                         <q-img class="wallet-img" :src="metamaskLogo"></q-img>
-                        <p>Metamask</p>
+                        <p>{{ !browserSupportsEthereum ? 'Continue on ' : '' }}Metamask</p>
                     </q-card>
                 </q-tab-panel>
                 <q-tab-panel name="native">

--- a/src/store/general/actions.js
+++ b/src/store/general/actions.js
@@ -1,1 +1,7 @@
+import detectEthereumProvider from '@metamask/detect-provider';
 
+export async function fetchBrowserEthereumSupport({ commit }) {
+    const provider = await detectEthereumProvider();
+
+    commit('setBrowserSupportsEthereum', !!provider);
+}

--- a/src/store/general/getters.js
+++ b/src/store/general/getters.js
@@ -1,5 +1,4 @@
 export const errorMsg = ({ errorMsg }) => errorMsg;
 export const successMsg = ({ successMsg }) => successMsg;
 export const isLoading = ({ isLoading }) => isLoading;
-
-
+export const browserSupportsEthereum = ({ browserSupportsEthereum }) => browserSupportsEthereum;

--- a/src/store/general/mutations.js
+++ b/src/store/general/mutations.js
@@ -10,3 +10,6 @@ export const setIsLoading = (state, isLoading) => {
     state.isLoading = isLoading;
 };
 
+export const setBrowserSupportsEthereum = (state, browserSupportsEthereum) => {
+    state.browserSupportsEthereum = browserSupportsEthereum;
+};

--- a/src/store/general/state.js
+++ b/src/store/general/state.js
@@ -2,4 +2,5 @@ export default () => ({
     errorMsg: null,
     successMsg: null,
     isLoading: null,
+    browserSupportsEthereum: null,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,6 +1620,11 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
+"@metamask/detect-provider@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/detect-provider/-/detect-provider-2.0.0.tgz#4bc2795e5e6f7d8b84b2e845058d2f222c99917d"
+  integrity sha512-sFpN+TX13E9fdBDh9lvQeZdJn4qYoRb/6QF2oZZK/Pn559IhCFacPMU1rMuqyXoFQF3JSJfii2l98B87QDPeCQ==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
# Fixes #202

## Description
Mobile clients do not inject `ethereum` into the `window` object, so effectively Ethereum is not supported in these cases. This PR adds a check to determine if ethereum is supported; if not, the login modal deeplinks to the MetaMask app.

This PR also converts `ConnectButton.vue`s template away from Pug

## Test scenarios
**Setup**
- run `yarn install && yarn dev`

**Regression Test**
- go to http://localhost:8080 in your desktop browser (which should have the MetaMask (hereafter, _MM_) extension installed)
- click the _Connect Wallet_ button
    - you should see the text "MetaMask" below the fox logo

- the MM extension should pop a window prompting you to sign in


**Mobile** 
- go to your machine's IP on your phone/tablet, which is printed in the console when you run yarn dev, eg. `192.168.1.420:8080`
- tap the _Connect Wallet_ button
    - you should see the text "Continue on MetaMask" below the fox logo
- click the MM logo
    - you should be taken to either the MetaMask app (displaying the correct IP address of your machine) or the App/Play Store to download metamask

**MetaMask Built-In Browser**
- go to your machine's IP from the MetaMask app's built-in browser on your phone/tablet, which is printed in the console when you run yarn dev, eg. `192.168.1.420:8080`
- tap the _Connect Wallet_ button
    - you should see the text "MetaMask" below the fox logo
- click the MM logo
    - the MM app should prompt you to connect your wallet