### PR TITLE
#90 | Checksum on address page

### DIFF
--- a/src/pages/AccountAddress.vue
+++ b/src/pages/AccountAddress.vue
@@ -1,4 +1,5 @@
 <script>
+import { toChecksumAddress } from 'src/lib/utils';
 import Web3 from 'web3';
 import TransactionTable from 'components/TransactionTable';
 import TransferTable from 'components/TransferTable';
@@ -41,13 +42,17 @@ export default {
     },
     computed: {
         address() {
-            return this.$route.params?.address?.toLowerCase() ?? '';
+            return this.$route.params?.address ?? '';
         },
     },
     watch: {
-        'address': {
+        address: {
             handler(newValue, oldValue) {
                 if (newValue !== oldValue) {
+                    const newAsChecksum = toChecksumAddress(newValue);
+                    if (newAsChecksum !== newValue) {
+                        this.$router.replace({ params: { address: newAsChecksum}});
+                    }
                     this.loadAccount();
                 }
             },


### PR DESCRIPTION
# Fixes #90

## Description
This PR ensures that the address page (and route) displays a checksum address rather than lowercase/arbitrary casing. It does so replacing the route with checksum address immediately on page load.

## Test scenarios

- go to an address page with a lowercase address, e.g. https://deploy-preview-268--benevolent-tapioca-f74277.netlify.app/address/0xdbb168a87b6c6c88b8f0f3172c8cb929cfd53265
    - you should be instantly redirected to the checksum version of the URL (the URL should have mixed case letters - e.g. it should start with `0xDbb` rather than `0xdbb`)
- click the copy button next to the address in the header
- paste the address somewhere
    - the copied address should be checksum

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
