### PR TITLE
fixed missing contract case on ERCTransfer component

### DIFF
--- a/src/components/Transaction/ERCTransferList.vue
+++ b/src/components/Transaction/ERCTransferList.vue
@@ -45,10 +45,10 @@ div(class="fit row wrap justify-start items-start content-start")
       div(class="col-4")
         q-icon(name="arrow_right" class="list-arrow")
         strong {{ `From : ` }}
-        <AddressField :highlight="trxFrom === transfer.from && transfers.length > 1" :address="transfer.from" :truncate="15" copy :name="transfer.from === contract.address && contract.name ?  contract.name : null" />
+        <AddressField :highlight="trxFrom === transfer.from && transfers.length > 1" :address="transfer.from" :truncate="15" copy :name="contract && transfer.from === contract.address && contract.name ?  contract.name : null" />
       div(class="col-3")
         strong {{ ` To : ` }}
-        <AddressField :highlight="trxFrom === transfer.to && transfers.length > 1" :address="transfer.to" :truncate="15" copy :name="transfer.to === contract.address && contract.name ?  contract.name : null" />
+        <AddressField :highlight="trxFrom === transfer.to && transfers.length > 1" :address="transfer.to" :truncate="15" copy :name="contract && transfer.to === contract.address && contract.name ?  contract.name : null" />
       div.flex(v-if="type === 'ERC721' || type==='ERC1155'" class="col-4")
         strong.col-2 {{ ` Token : ` }}
         router-link(:to="'/address/' + transfer.token.address" class="q-ml-xs") {{ transfer.token.symbol }}

--- a/src/pages/Transaction.vue
+++ b/src/pages/Transaction.vue
@@ -107,7 +107,7 @@ export default {
         {
             this.transfers = [];
             for (const log of this.trx.logs) {
-                // ERC20 & ERC721 transfers (ERC721 has 4 log topics for transfers, ERC20 has 3 log topics)
+                // ERC20, ERC721 & ERC1155 transfers (ERC721 & ERC20 have same first topic but ERC20 has 4 topics for transfers, ERC20 has 3 log topics, ERC1155 has a different first topic)
                 let sig = log.topics[0].substr(0, 10);
                 if (TRANSFER_SIGNATURES.includes(sig)) {
                     let type = this.$contractManager.getTokenTypeFromLog(log);
@@ -140,6 +140,7 @@ export default {
                             }
                             this.erc1155Transfers.push({
                                 'tokenId': tokenId,
+                                'amount': BigNumber.from(log.data).toString(),
                                 'to': '0x' + log.topics[3].substr(log.topics[3].length - 40, 40),
                                 'from': '0x' + log.topics[2].substr(log.topics[2].length - 40, 40),
                                 'token': token,


### PR DESCRIPTION
# Fixes #269 

## Description

Fixes transfers not showing up on the main transaction page in some specific cases (ie: contract deploy + mint)

## Test scenarios

-   [x] Transactions that deploy a contract then transfer token should show the transfers

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
