### PR TITLE
#266 | Make contract interface results links for addresses

### DIFF
--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -85,7 +85,9 @@
         {{ errorMessage }}
     </p>
     <div v-if="result" class="output-container">
-        Result ({{ abi.outputs && abi.outputs.length > 0 ? abi.outputs[0].type : '' }}): {{ result }}
+        Result ({{ abi.outputs && abi.outputs.length > 0 ? abi.outputs[0].type : '' }}):
+        <router-link v-if="abi?.outputs?.[0]?.type === 'address'" :to="`/address/${result}`" >{{ result }}</router-link>
+        <template v-else>{{ result }}</template>
     </div>
     <div v-if="hash" class="output-container">
         View Transaction:&nbsp;


### PR DESCRIPTION
# Fixes #266

## Description

This PR adds in detection for contract interface results to see if they are an address, and if so, render a link to their address page

## Test scenarios

- go to /address/0xc9e2af6d4efea2bddc2e836f79272b367fad1712#contract
- click on 'Read'
- scroll to the function called `owner`
- execute the function
    - you should see "Result (address): 0x3b946C2C84a316Fe8821D1662b83AF5521537943"
    - the address should link to the address page
- execute the `name` function
    - you should see "Result (string): Aurora Name Service (.aurora)" with no link

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
