### PR TITLE
Merging all together: English, Spanish, and Header translation

### DIFF
--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -50,6 +50,11 @@ export default {
                     break;
                 default:
                     console.error(`Unknown web3 login type: ${loginObj.provider}`);
+                    this.$q.notify({
+                        position: 'top',
+                        message: this.$t('components.unknown_web3_login_type', {provider: loginObj.provider}),
+                        timeout: 6000,
+                    });
                     break;
                 }
             }

--- a/src/components/header/AppHeader.vue
+++ b/src/components/header/AppHeader.vue
@@ -57,7 +57,7 @@
                     class="c-header__menu-item-icon"
                     size="sm"
                 />
-                Sign {{ isLoggedIn ? 'Out' : 'In'}}
+                {{ isLoggedIn ? $t('components.header.sign_out') : $t('components.header.sign_in') }}
             </li>
 
             <q-separator class="c-header__menu-separator"/>
@@ -66,7 +66,7 @@
                 class="c-header__menu-li cursor-pointer"
                 tabindex="0"
                 role="link"
-                aria-label="Go to Staking"
+                :arial-label="$t('components.header.goto_staking')"
                 @keydown.enter="goTo({ name: 'staking' })"
                 @click="goTo({ name: 'staking' })"
             >
@@ -76,7 +76,7 @@
                     class="c-header__menu-item-icon c-header__menu-item-icon--stlos"
                     width="24"
                 >
-                Liquid Staking
+                {{ $t('components.header.liq_staking') }}
             </li>
 
             <q-separator class="c-header__menu-separator"/>
@@ -97,7 +97,7 @@
                         @keydown.enter="advancedMenuExpanded = !advancedMenuExpanded"
                         @click="advancedMenuExpanded = !advancedMenuExpanded"
                     >
-                        Advanced
+                        {{ $t('components.header.advanced') }}
 
                         <q-icon
                             :name="advancedMenuExpanded ? 'expand_less' : 'expand_more'"
@@ -109,7 +109,7 @@
                         <li
                             class="c-header__menu-li"
                             tabindex="0"
-                            aria-label="go to Heath Monitor page"
+                            :aria-label="`${$t('components.header.goto_health_monitor')}`"
                             role="link"
                             @keydown.enter="goTo('/health')"
                             @click="goTo('/health')"
@@ -119,13 +119,14 @@
                                 class="c-header__menu-item-icon"
                                 size="sm"
                             />
-                            Health Status
+                            {{ $t('components.header.health_monitor') }}
+
                         </li>
                         <li
                             class="c-header__menu-li"
                             tabindex="0"
-                            :aria-label="`go to ${isTestnet ? 'main net' : 'test net'}`"
                             role="link"
+                            :aria-label="isTestnet ? $t('components.header.goto_mainnet') : $t('components.header.goto_testnet')"
                             @keydown.enter="goTo(isTestnet ? 'https://teloscan.io' : 'https://testnet.teloscan.io')"
                             @click="goTo(isTestnet ? 'https://teloscan.io' : 'https://testnet.teloscan.io')"
                         >
@@ -144,7 +145,7 @@
                 <li
                     class="c-header__menu-li c-header__menu-li--advanced-menu-mobile"
                     tabindex="0"
-                    aria-label="go to Heath Monitor page"
+                    :aria-label="$t('components.header.goto_health_monitor')"
                     role="link"
                     @keydown.enter="goTo('/health')"
                     @click="goTo('/health')"
@@ -154,7 +155,7 @@
                         class="c-header__menu-item-icon"
                         size="sm"
                     />
-                    Health Status
+                    {{ $t('components.header.health_status') }}
                 </li>
                 <li
                     class="c-header__menu-li c-header__menu-li--advanced-menu-mobile"
@@ -189,7 +190,7 @@
                     class="c-header__menu-item-icon"
                     size="sm"
                 />
-                {{ $q.dark.isActive ? 'Light' : 'Dark'}} Mode
+                {{ $q.dark.isActive ? $t('components.header.light_mode') : $t('components.header.dark_mode') }}
             </li>
         </ul>
     </div>

--- a/src/components/header/HeaderSearch.vue
+++ b/src/components/header/HeaderSearch.vue
@@ -48,7 +48,7 @@ export default {
 
                     this.$q.notify({
                         position: 'top',
-                        message: `Search for EVM address linked to ${this.searchTerm} native account failed.`,
+                        message: this.$('components.header.address_not_found', { account: this.searchTerm }),
                         timeout: this.TIME_DELAY,
                     });
                     return;
@@ -60,7 +60,7 @@ export default {
 
             this.$q.notify({
                 position: 'top',
-                message: 'Search failed, please enter a valid search term.',
+                message: this.$('components.header.search_failed'),
                 timeout: this.TIME_DELAY,
             });
         },
@@ -92,7 +92,7 @@ export default {
         :bg-color="$q.dark.isActive ? 'grey-9' : 'grey-3'"
         color="black"
         hide-bottom-space
-        placeholder="Address, Tx, Block"
+        :placeholder="$t('components.header.search_placeholder')"
         @keydown.enter="search"
     >
         <template v-slot:append>

--- a/src/components/header/LoginStatus.vue
+++ b/src/components/header/LoginStatus.vue
@@ -14,7 +14,7 @@
             @click="goToAddress"
         />
         <q-tooltip>
-            Go to Address Details
+            {{ $t('compontns.header.goto_address_details') }}
         </q-tooltip>
     </div>
 
@@ -26,7 +26,7 @@
             @click="copy"
         />
         <q-tooltip>
-            Copy Address
+            {{ $t('components.header.copy_address') }}
         </q-tooltip>
     </div>
 </div>
@@ -66,7 +66,7 @@ export default {
 
             this.$q.notify({
                 position: 'bottom',
-                message: 'Address copied',
+                message: this.$t('components.header.address_copied'),
                 color: 'green',
             });
         },

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -36,6 +36,8 @@ export default {
             withdraw: 'Withdraw',
             telos_evm_staking: 'Telos EVM Staking',
             stake_tlos_earn_interest: 'Stake TLOS for sTLOS to earn interest from the staking rewards pool',
+            staked: 'Staked',
+            unstaked: 'Unstaked',
             tooltip_1: 'APY: Annual Percentage Yield\n\nThe annual rate of return after taking compound interest into account.\n\n' +
             'Interest is compounded approximately every 30 minutes. The percentage rate is not fixed, meaning that ' +
             'it will change over time with the total amount of TLOS staked across Telos EVM and Native. ' +
@@ -176,12 +178,12 @@ export default {
         input: 'Input',
         output: 'Output',
         value: 'Value',
-
     },
     components: {
         verify_prompt: 'This contract has not been verified.  Would you like to upload the contract(s) and metadata to verify source now?',
         verify_contract: 'Verify Contract',
         search_evm_address_failed: 'Search for EVM address linked to { accountName } native account failed. You can create one at wallet.telos.net',
+        unknown_web3_login_type: 'Unknown web3 login type: { provider }',
         connect_wallet: 'Connect Wallet',
         view_address: 'View Address',
         disconnect: 'Disconnect',
@@ -316,6 +318,26 @@ export default {
             read_functions: 'Read functions',
             write_functions: 'Write functions',
             unverified_contract: 'Unverified contract',
+        },
+        header: {
+            sign_in: 'Sign in',
+            sign_out: 'Sign out',
+            liq_staking: 'Liquid Staking',
+            goto_staking: 'Go to Staking',
+            goto_health_monitor: 'go to Heath Monitor page',
+            goto_mainnet: 'Go to Mainnet',
+            goto_testnet: 'Go to Testnet',
+            health_monitor: 'Health Monitor',
+            health_status: 'Health Status',
+            advanced: 'Advanced',
+            light_mode: 'Light Mode',
+            dark_mode: 'Dark Mode',
+            address_not_found: 'Search for EVM address linked to { account } native account failed.',
+            search_failed: 'Search failed, please enter a valid search term.',
+            goto_address_details: 'Go to address details',
+            copy_address: 'Copy address',
+            address_copied: 'Address copied to clipboard',
+            search_placeholder: 'Address, Tx, Block',
         },
     },
     layouts: {

--- a/src/i18n/es-es/index.js
+++ b/src/i18n/es-es/index.js
@@ -36,6 +36,8 @@ export default {
             withdraw: 'Retirar',
             telos_evm_staking: 'Bloqueo de TLOS en EVM',
             stake_tlos_earn_interest: 'Bloquear TLOS para obtener sTLOS y ganar intereses de la recompensa de bloqueo',
+            staked: 'Bloqueado',
+            unstaked: 'Desbloqueado',
             tooltip_1: 'TAE: Tasa Anual Efectiva (APY en Inglés)\n\nLa tasa de retorno anual después de tomar en cuenta el interés compuesto.\n\n' +
             'El interés se compone aproximadamente cada 30 minutos. La tasa porcentual no es fija, lo que significa que ' +
             'cambiará con el tiempo con la cantidad total de TLOS bloqueado en Telos EVM y Telos nativo. ' +
@@ -128,6 +130,7 @@ export default {
         paste_contract_code_here: 'copie y pegue el código del contrato aquí...',
         enter_contract_text: 'ingrese o pegue el texto del contrato',
         verify_contract: 'Verificar contrato',
+        dismiss: 'Descartar',
         reset: 'Reiniciar',
         gas_used: 'Gas usado',
         transactions: 'Transacciones',
@@ -136,6 +139,7 @@ export default {
         erc20_transfers: 'Transferencias ERC20',
         erc721_transfers: 'Transferencias ERC721',
         erc1155_transfers: 'Transferencias ERC1155',
+        tokens: 'Tokens',
         created_at_trx: 'Creada en la Trx',
         by_address: 'Por la dirección',
         number_used_once: 'Número usado una vez (nonce)',
@@ -179,6 +183,7 @@ export default {
         verify_prompt: 'Este contrato no ha sido verificado. ¿Le gustaría cargar el (los) contrato (s) y los metadatos para verificar el código fuente ahora?',
         verify_contract: 'Verificar contrato',
         search_evm_address_failed: 'La búsqueda de la dirección EVM vinculada a la cuenta nativa { accountName } falló. Puede crear una en wallet.telos.net',
+        unknown_web3_login_type: 'Tipo de inicio de sesión web3 desconocido: { provider }',
         connect_wallet: 'Conectar billetera',
         view_address: 'Ver dirección',
         disconnect: 'Desconectar',
@@ -314,6 +319,26 @@ export default {
             write_functions: 'Funciones de escritura',
             unverified_contract: 'Contrato no verificado',            
         },
+        header: {
+            sign_in: 'Iniciar sesión',
+            sign_out: 'Cerrar sesión',
+            liq_staking: 'Bloqueado líquido',
+            goto_staking: 'Ir a Bloqueado',
+            goto_health_monitor: 'ir a la página de monitoreo de salud',
+            goto_mainnet: 'Ir a Mainnet',
+            goto_testnet: 'Ir a Testnet',
+            health_monitor: 'Monitoreo de salud',
+            health_status: 'Estado de la salud',
+            advanced: 'Avanzado',
+            light_mode: 'Modo claro',
+            dark_mode: 'Modo oscuro',
+            address_not_found: 'La búsqueda de la dirección EVM vinculada a la cuenta nativa { account } falló.',
+            search_failed: 'La búsqueda falló, ingrese un término de búsqueda válido.',
+            goto_address_details: 'Ir a los detalles de la dirección',
+            copy_address: 'Copiar dirección',
+            address_copied: 'Dirección copiada al portapapeles',
+            search_placeholder: 'Dirección, Tx, Bloque',
+        },
     },
     layouts: {
         health_status: 'Estado de la salud',
@@ -321,4 +346,4 @@ export default {
         teloscan_mainnet: 'Teloscan Mainnet',
         teloscan_testnet: 'Teloscan Testnet',
     },
-}
+};

--- a/src/pages/staking/StakeForm.vue
+++ b/src/pages/staking/StakeForm.vue
@@ -72,7 +72,7 @@
                     v-if="showMetamaskPrompt"
                     class="c-stake-form__metamask-prompt u-flex--center-y"
                     tabindex="0"
-                    aria-:label="$t('pages.staking.add_stlos_to_metamask')"
+                    :aria-label="$t('pages.staking.add_stlos_to_metamask')"
 
                     @click="promptAddToMetamask"
                 >
@@ -93,7 +93,7 @@
                 />
                 <q-btn
                     v-close-popup
-                    label="Stake TLOS"
+                    :label="$t('pages.staking.stake_tlos')"
                     color="secondary"
                     text-color="black"
                     @click="initiateDeposit"

--- a/src/pages/staking/StakingStats.vue
+++ b/src/pages/staking/StakingStats.vue
@@ -129,7 +129,7 @@ export default {
         personalStats() {
             return {
                 staked: {
-                    label: 'Staked',
+                    label: this.$t('pages.staking.staked'),
                     value: {
                         stlos: this.formatWeiForStats(this.stlosBalance),
                         tlos: this.formatWeiForStats(this.stlosValue),
@@ -137,7 +137,7 @@ export default {
                     tooltip: this.$t('pages.staking.tooltip_3'),
                 },
                 unstaked: {
-                    label: 'Unstaked',
+                    label: this.$t('pages.staking.unstaked'),
                     value: this.formatWeiForStats(this.totalUnstakedTlosBalance),
                     tooltip: this.$t('pages.staking.tooltip_4', { unlockPeriod: this.unlockPeriodPretty }),
                 },

--- a/src/pages/staking/WithdrawPage.vue
+++ b/src/pages/staking/WithdrawPage.vue
@@ -115,19 +115,23 @@ export default {
         columns: [
             {
                 name: 'amount',
-                label: 'Amount',
+                label: '',
                 field: 'amount',
                 sortable: true,
             },
             {
                 name: 'time',
-                label: 'Available to Withdraw',
+                label: '',
                 field: 'until',
                 sortable: true,
             },
         ],
         showAge: true,
     }),
+    created() {
+        this.columns[0].label = this.$t('pages.staking.amount');
+        this.columns[1].label = this.$t('pages.staking.available_to_withdraw');
+    },
     computed: {
         ...mapGetters('login', ['isLoggedIn', 'isNative']),
         withdrawDisabled(){


### PR DESCRIPTION
# Fixes #315 and partially #313

## Description
This PR merges all together: the Spanish and English translations along with the new Header code being translated as well. 

## Test scenarios
- The structure of the files `src/i18n/en-us/index.js` and `src/i18n/es-es/index.js` should be identical
- When you explore the site with the browser console opened you should see no warning about any missing i18n variable
- No hardcoded texts should be present on the code (other than those files)

## Checklist:
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
