### PR TITLE
#313 | Header language switcher

### DIFF
--- a/src/boot/i18n.js
+++ b/src/boot/i18n.js
@@ -3,12 +3,44 @@ import { createI18n } from 'vue-i18n';
 import messages from 'src/i18n';
 
 export default boot(({ app }) => {
+    // Get user's last chosen language from local storage
+    let lastChosenLanguage = localStorage.getItem('language')
+
+    //if not present in local storage then check user browser language
+    if(!lastChosenLanguage) {
+        lastChosenLanguage = navigator.language.toLowerCase().split(/[_-]+/)[0]
+    }
+    // Check if the browser language is supported, if not, fall back to 'en-us'
+    if(!Object.keys(messages).includes(lastChosenLanguage)) {
+        lastChosenLanguage = 'en-us';
+    }
+
+    // Create the i18n instance
     const i18n = createI18n({
-        locale: 'en-us',
+        locale: lastChosenLanguage,
         globalInjection: true,
         messages,
     });
 
     // Set i18n instance on app
     app.use(i18n);
+
+
+    // Listen for language-changed event
+    const setLocale = (newLanguage) => {
+        const currentLanguage = localStorage.getItem('language');
+
+        if (newLanguage !== currentLanguage) {
+            localStorage.setItem('language', newLanguage);
+            window.location.reload();
+        }
+        // TODO: investigate if there is a better way to change the language not reloading the page
+        // i18n.locale = newLanguage;
+        // i18n.global.setLocaleMessage(newLanguage, messages[newLanguage]);
+        // app.use(i18n);
+    }
+
+    // Set setLocale and i18n reference available for global access
+    app.config.globalProperties.$setLocale = setLocale;
+    app.config.globalProperties.$i18n = i18n;
 });

--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -25,14 +25,14 @@
                     <q-btn
                         v-close-popup
                         flat="flat"
-                        :label="$t('components.contract_tab.ok')"
+                        :label="$t('global.ok')"
                         color="primary"
                         @click="setAmount"
                     />
                     <q-btn
                         v-close-popup
                         flat="flat"
-                        :label="$t('components.contract_tab.cancel')"
+                        :label="$t('global.cancel')"
                         color="primary"
                         @click="clearAmount"
                     />

--- a/src/components/header/AppHeader.vue
+++ b/src/components/header/AppHeader.vue
@@ -109,6 +109,21 @@
                         <li
                             class="c-header__menu-li"
                             tabindex="0"
+                            role="menuitem"
+                            :aria-label="'open language switcher'"
+                            @keydown.enter="showLanguageSwitcher = true"
+                            @click="showLanguageSwitcher = true"
+                        >
+                            <q-icon
+                                name="language"
+                                class="c-header__menu-item-icon"
+                                size="sm"
+                            />
+                            {{ $t('global.language') }}
+                        </li>
+                        <li
+                            class="c-header__menu-li"
+                            tabindex="0"
                             :aria-label="`${$t('components.header.goto_health_monitor')}`"
                             role="link"
                             @keydown.enter="goTo('/health')"
@@ -142,6 +157,21 @@
             </li>
 
             <template v-if="advancedMenuExpanded">
+                <li
+                    class="c-header__menu-li c-header__menu-li--advanced-menu-mobile"
+                    tabindex="0"
+                    role="menuitem"
+                    :aria-label="'open language switcher'"
+                    @keydown.enter="showLanguageSwitcher = true"
+                    @click="showLanguageSwitcher = true"
+                >
+                    <q-icon
+                        name="language"
+                        class="c-header__menu-item-icon"
+                        size="sm"
+                    />
+                    {{ $t('global.language') }}
+                </li>
                 <li
                     class="c-header__menu-li c-header__menu-li--advanced-menu-mobile"
                     tabindex="0"
@@ -196,6 +226,7 @@
     </div>
 </header>
 <login-modal :show="showLoginModal" @hide="showLoginModal = false" />
+<language-switcher-modal :show="showLanguageSwitcher" @hide="showLanguageSwitcher = false" />
 <q-scroll-observer @scroll="scrollHandler" />
 </template>
 
@@ -204,13 +235,15 @@ import { mapGetters, mapMutations } from 'vuex';
 import { stlos as stlosLogo } from 'src/lib/logos.js';
 import { directive as clickaway } from 'vue3-click-away';
 
-import LoginModal from 'components/LoginModal.vue';
 import HeaderSearch from 'components/header/HeaderSearch.vue';
+import LanguageSwitcherModal from 'components/header/LanguageSwitcherModal.vue';
+import LoginModal from 'components/LoginModal.vue';
 import LoginStatus from 'components/header/LoginStatus.vue';
 
 export default {
     name: 'AppHeader',
     components: {
+        LanguageSwitcherModal,
         LoginModal,
         HeaderSearch,
         LoginStatus,
@@ -222,6 +255,7 @@ export default {
         stlosLogo,
         mobileMenuIsOpen: false,
         showLoginModal: false,
+        showLanguageSwitcher: false,
         advancedMenuExpanded: false,
         menuHiddenDesktop: false,
         isTestnet: process.env.NETWORK_EVM_CHAIN_ID !== '40',

--- a/src/components/header/LanguageSwitcherModal.vue
+++ b/src/components/header/LanguageSwitcherModal.vue
@@ -1,0 +1,87 @@
+<script>
+import messages from 'src/i18n';
+
+export default {
+    name: 'LanguageSwitcherModal',
+    emits: ['hide'],
+    props: {
+        show: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    data: () => ({
+        selectedLanguage: null,
+
+        languageOptions: null,
+    }),
+    created() {
+        this.selectedLanguage = {
+            code: this.$i18n.locale,
+            name: this.$t('locale.current_language_name'),
+        };
+        // debugger;
+
+        // languageOptions: [
+        //     { code: 'en-us', name: 'English'},
+        //     { code: 'es-es', name: 'Español'},
+        //     ...
+        // ],
+        this.languageOptions = Object.keys(messages).map((key) => ({
+            code: key,
+            name: messages[key].locale.current_language_name,
+        }));
+    },
+    watch: {
+        'selectedLanguage.code'(newCode, oldCode) {
+            if (newCode !== oldCode) {
+                this.changeLanguage();
+            }
+        },
+    },
+    methods: {
+        changeLanguage() {
+            console.log('changeLanguage()', this.selectedLanguage.code);
+            console.log('typeof $setLocale.setLocale', typeof this.$setLocale);
+            this.$setLocale(this.selectedLanguage.code);
+        },
+    },
+}
+</script>
+
+<template>
+<q-dialog :model-value="show" @hide="() => $emit('hide')">
+    <q-card rounded class="c-language-switcher__card">
+        <q-card-section class="q-pa-md">
+            <p class="text-h6">
+                {{ $t('components.header.select_language') }}
+            </p>
+
+            <q-select
+                v-model="selectedLanguage"
+                :options="languageOptions"
+                option-value="code"
+                option-label="name"
+                class="q-mb-lg"
+            />
+
+            <q-card-actions align="right">
+                <q-btn
+                    flat
+                    :label="$t('global.cancel')"
+                    v-close-popup
+                />
+            </q-card-actions>
+        </q-card-section>
+    </q-card>
+</q-dialog>
+</template>
+
+<style lang="scss">
+.c-language-switcher {
+    &__card {
+        width: 700px;
+        max-width: 80vw;
+    }
+}
+</style>

--- a/src/components/header/LanguageSwitcherModal.vue
+++ b/src/components/header/LanguageSwitcherModal.vue
@@ -20,7 +20,6 @@ export default {
             code: this.$i18n.locale,
             name: this.$t('locale.current_language_name'),
         };
-        // debugger;
 
         // languageOptions: [
         //     { code: 'en-us', name: 'English'},

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -1,4 +1,7 @@
 export default {
+    locale: {
+        current_language_name: 'English',
+    },
     pages: {
         staking: {
             note_unstaking_period: 'Please note that there is an unstaking period of {period}',
@@ -47,7 +50,7 @@ export default {
             tooltip_3: 'Staked\n\n' +
             'The total staked amount associated with the logged-in account, i.e. ' +
             'your sTLOS token balance, along with its value in TLOS',
-            tooltip_4: 'Unstaked\n\n' + 
+            tooltip_4: 'Unstaked\n\n' +
             'The total value of TLOS which you have unstaked, both locked and unlocked.\n\n' +
             'When you unstake\u2014i.e. redeem\u2014some value of sTLOS, the equivalent amount of ' +
             'TLOS is sent into escrow ("locked") for {unlockPeriod}; during this time, ' +
@@ -130,7 +133,6 @@ export default {
         paste_contract_code_here: 'copy & paste contract code here...',
         enter_contract_text: 'enter or paste contract text',
         verify_contract: 'Verify Contract',
-        dismiss: 'Dismiss',
         reset: 'Reset',
         gas_used: 'Gas used',
         transactions: 'Transactions',
@@ -281,7 +283,7 @@ export default {
             address_label: '{ label } (address)',
             boolean_array_label: '{ label } (bool[{ size }])',
         },
-        health: {   
+        health: {
             status: 'Status',
             checked_at: 'Checked at',
             task: 'Task',
@@ -300,13 +302,11 @@ export default {
             write: 'Write',
             amount: 'Amount',
             value: 'Value',
-            ok: 'Ok',
-            cancel: 'Cancel',
             custom_decimals: 'Custom decimals',
             custom: 'Custom',
             unverified_contract_source: 'This contract source has not been verified.',
             click_here: 'Click here',
-            upload_source_files: 'to upload source files and verify this contract. ' + 
+            upload_source_files: 'to upload source files and verify this contract. ' +
                 'Alternatively, you can interact with the contract using an arbitrary ABI:',
             use_erc20_abi: 'Use ERC20 ABI',
             use_erc721_abi: 'Use ERC721 ABI',
@@ -338,7 +338,14 @@ export default {
             copy_address: 'Copy address',
             address_copied: 'Address copied to clipboard',
             search_placeholder: 'Address, Tx, Block',
+            select_language: 'Select Language',
         },
+    },
+    global: {
+        language: 'Language',
+        cancel: 'Cancel',
+        ok: 'Ok',
+        dismiss: 'Dismiss',
     },
     layouts: {
         health_status: 'Health Status',

--- a/src/i18n/es-es/index.js
+++ b/src/i18n/es-es/index.js
@@ -1,11 +1,13 @@
 export default {
+    locale: {
+        current_language_name: 'Español',
+    },
     pages: {
         staking: {
             note_unstaking_period: 'Tenga en cuenta que hay un período de recuperación de {period}',
             claim_tlos: 'Reclamar TLOS',
             add_stlos_to_metamask: 'Iniciar el cuadro de diálogo MetaMask para agregar sTLOS',
             metamask_fox_logo: 'Logotipo de la zorra de MetaMask',
-            cancel: 'Cancelar',
             stake_tlos_confirm: 'continuar significa bloquer TLOS a cambio de sTLOS. ' +
             'sTLOS se puede canjear por TLOS en cualquier momento usando la pestaña Desbloquear.',
             stake_tlos_confirm_2a: 'Después de que se reclamen los TLOS, éstos estarán bloqueados durante un período de', /* unstakePeriodPretty...*/
@@ -101,7 +103,7 @@ export default {
             convert_tlos_to_stlos_error: 'No se puede convertir TLOS a sTLOS { message }',
             convert_stlos_to_tlos_error: 'No se puede convertir sTLOS a TLOS { message }',
             unstake_stlos_error: 'Error al desbloquear sTLOS { message }',
-            withdraw_failed: 'Error al retirar TLOS desbloqueado: { message }',  
+            withdraw_failed: 'Error al retirar TLOS desbloqueado: { message }',
         },
         explore_transactions: 'Explorar transacciones',
         recent_transactions: 'Transacciones recientes',
@@ -130,7 +132,6 @@ export default {
         paste_contract_code_here: 'copie y pegue el código del contrato aquí...',
         enter_contract_text: 'ingrese o pegue el texto del contrato',
         verify_contract: 'Verificar contrato',
-        dismiss: 'Descartar',
         reset: 'Reiniciar',
         gas_used: 'Gas usado',
         transactions: 'Transacciones',
@@ -244,7 +245,7 @@ export default {
             no_internal_trxs_found: 'No se encontraron transacciones internas',
             human_readable: 'Lectura humana',
             no_logs_found: 'No se encontraron registros',
-            verify_related_contract: 'Verifique el contrato relacionado para cada registro para ver su versión legible por humanos',      
+            verify_related_contract: 'Verifique el contrato relacionado para cada registro para ver su versión legible por humanos',
             failed_to_retrieve_contract: 'No se pudo recuperar el contrato con la dirección { address }',
         },
         inputs: {
@@ -279,7 +280,7 @@ export default {
             str_input_hint: 'Las comillas dobles en las cadenas deben escaparse (\\")',
             address_placeholder: 'Dirección que comienza con 0x',
             address_label: '{ label } (address)',
-            boolean_array_label: '{ label } (bool[{ size }])',            
+            boolean_array_label: '{ label } (bool[{ size }])',
         },
         health: {
             status: 'Estado',
@@ -300,8 +301,6 @@ export default {
             write: 'Escribir',
             amount: 'Cantidad',
             value: 'Valor',
-            ok: 'Ok',
-            cancel: 'Cancelar',
             custom_decimals: 'Decimales personalizados',
             custom: 'Personalizado',
             unverified_contract_source: 'El código fuente de este contrato no ha sido verificado.',
@@ -317,7 +316,7 @@ export default {
             provided_json_invalid: 'JSON proporcionado no válido',
             read_functions: 'Funciones de lectura',
             write_functions: 'Funciones de escritura',
-            unverified_contract: 'Contrato no verificado',            
+            unverified_contract: 'Contrato no verificado',
         },
         header: {
             sign_in: 'Iniciar sesión',
@@ -338,7 +337,14 @@ export default {
             copy_address: 'Copiar dirección',
             address_copied: 'Dirección copiada al portapapeles',
             search_placeholder: 'Dirección, Tx, Bloque',
+            select_language: 'Seleccionar idioma',
         },
+    },
+    global: {
+        language: 'Idioma',
+        ok: 'Ok',
+        cancel: 'Cancelar',
+        dismiss: 'Descartar',
     },
     layouts: {
         health_status: 'Estado de la salud',

--- a/src/pages/staking/StakeForm.vue
+++ b/src/pages/staking/StakeForm.vue
@@ -13,7 +13,7 @@
                 <q-btn
                     flat
                     color="black"
-                    :label="$t('pages.staking.dismiss')"
+                    :label="$t('global.dismiss')"
                     @click="hideClaimBanner"
                 />
                 <q-btn
@@ -88,7 +88,7 @@
                 <q-btn
                     v-close-popup
                     flat
-                    :label="$t('pages.staking.cancel')"
+                    :label="$t('global.cancel')"
                     color="negative"
                 />
                 <q-btn

--- a/src/pages/staking/UnstakeForm.vue
+++ b/src/pages/staking/UnstakeForm.vue
@@ -35,7 +35,7 @@
                     {{ $t('pages.staking.confirm_unstake_1a') }}
                     <span class="text-primary">{{ unstakePeriodPretty }}</span>,
                     {{ $t('pages.staking.confirm_unstake_1b') }}
-                    
+
                 </p>
                 <p v-if="remainingDeposits < 10">
                     {{ $t('pages.staking.confirm_unstake_2a') }}
@@ -43,14 +43,14 @@
                     {{ $t('pages.staking.confirm_unstake_2b') }}
 
                 </p>
-                {{ $t('pages.staking.confirm_unstake_3') }}
+                {{ $t('pages.staking.stake_tlos_confirm_3') }}
             </q-card-section>
 
             <q-card-actions align="right" class="q-pb-md q-px-md">
                 <q-btn
                     v-close-popup
                     flat
-                    :label="$t('pages.staking.cancel')"
+                    :label="$t('global.cancel')"
                     color="negative"
                 />
                 <q-btn
@@ -216,7 +216,7 @@ export default {
         this.bottomInputLabel = this.$t('pages.staking.receive_tlos');
         this.columns[0].label = this.$t('pages.staking.amount');
         this.columns[1].label = this.$t('pages.staking.time_remaining');
-        
+
         try {
             this.maxDeposits = (await this.escrowContractInstance.maxDeposits()).toNumber();
         } catch (error) {


### PR DESCRIPTION
# Fixes #313

## Description
This PR adds a language switcher to the header, as well as fixes a couple missing translations

Big thanks to @Viterbo for the js to make the language switcher work
 

## Test scenarios
**Broken translations**
- log in
- go to https://deploy-preview-318--teloscan-stage.netlify.app/staking
- enter any amount into the staking form
- click "Stake"
    - all localizations in the confirmation modal should look good
- go to https://deploy-preview-318--teloscan-stage.netlify.app/staking#unstake
- enter any amount into the unstake form
- click "Unstake"
    - all localizations in the confirmation modal should look good

**Language switcher**
- on both mobile and desktop:
- click Advanced on the site header
- click Language
    - a language switcher modal should come up 
- select a different language
    - app should reload with new language 

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
