### PR TITLE
fixing variable typo

### DIFF
--- a/src/components/header/LoginStatus.vue
+++ b/src/components/header/LoginStatus.vue
@@ -14,7 +14,7 @@
             @click="goToAddress"
         />
         <q-tooltip>
-            {{ $t('compontns.header.goto_address_details') }}
+            {{ $t('components.header.goto_address_details') }}
         </q-tooltip>
     </div>
 


### PR DESCRIPTION
# Fixes #325 

## Description
The text was not showing because of a typo in the variable name

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
