### PR TITLE
New tab for show internal transactions history for a given address

### DIFF
--- a/src/components/InternalTransactionTable.vue
+++ b/src/components/InternalTransactionTable.vue
@@ -79,6 +79,7 @@ export default {
                 rowsPerPage: 10,
                 rowsNumber: 0,
             },
+            page_size_options: [10, 20, 50],
             showDateAge: true,
         };
     },
@@ -95,7 +96,7 @@ export default {
             handler(_pag) {
                 let pag = _pag;
                 let page = 1;
-                let size = this.pagination.rowsPerPage;
+                let size = this.page_size_options[0];
 
                 // we also allow to pass a single number as the page number
                 if (typeof pag === 'number') {
@@ -258,7 +259,7 @@ export default {
     :row-key="row => row.hash"
     :columns="columns"
     :loading="loading"
-    :rows-per-page-options="[10, 20, 50]"
+    :rows-per-page-options="page_size_options"
     flat
     @request="onPaginationChange"
 >

--- a/src/components/InternalTransactionTable.vue
+++ b/src/components/InternalTransactionTable.vue
@@ -7,6 +7,9 @@ import { formatWei } from 'src/lib/utils';
 import { TRANSFER_SIGNATURES } from 'src/lib/abi/signature/transfer_signatures';
 import InternalTxns from 'components/Transaction/InternalTxns';
 
+const PAGE_KEY = 'page';
+const PSIZE_KEY = 'pagesize';
+
 export default {
     name: 'InternalTransactionTable',
     components: {
@@ -85,13 +88,57 @@ export default {
         this.columns[4].label = this.$t('components.internal_txns');
     },
     mounted() {
-        this.onRequest({
-            pagination: this.pagination,
-        });
+        addEventListener('popstate', this.popstate.bind(this));
+        // restoring a possible last pagination state from the URL
+        const params = new URLSearchParams(window.location.search);
+        let page = params.get(PAGE_KEY) || window.history.state?.pagination?.page;
+        let size = params.get(PSIZE_KEY) || window.history.state?.pagination?.size;
+        this.setPagination(page, size);
+    },
+    beforeUnmount() {
+        window.removeEventListener('popstate', this.popstate);
     },
     methods: {
+        popstate(event) {
+            const page = event.state.pagination.page;
+            const size = event.state.pagination.size;
+            this.setPagination(page, size);
+        },
+        setPagination(page, size) {
+            if (page) {
+                this.pagination.page = Number(page);
+            }
+            if (size) {
+                this.pagination.rowsPerPage = Number(size);
+            }
+            this.onRequest({
+                pagination: this.pagination,
+            });
+        },
         async onRequest(props) {
             this.loading = true;
+
+            // saving last pagination state
+            const url = new URL(window.location);
+            url.searchParams.set(PAGE_KEY, props.pagination.page);
+            url.searchParams.set(PSIZE_KEY, props.pagination.rowsPerPage);
+            const pagination = {
+                page: props.pagination.page,
+                size: props.pagination.rowsPerPage,
+            };
+            const params = new URLSearchParams(window.location.search);
+            const page_url = params.get(PAGE_KEY);
+            const size_url = params.get(PSIZE_KEY);
+            // this is a workaround to avoid the pushState() to fail
+            // https://github.com/vuejs/router/issues/366#issuecomment-1408501848
+            const current = '/';
+            if (this.pagination.page !== props.pagination.page ||
+                this.pagination.rowsPerPage !== props.pagination.rowsPerPage
+            ) {
+                window.history.pushState({ pagination, current }, '', url.toString());
+            } else if (!page_url || !size_url) {
+                window.history.replaceState({ pagination, current }, '', url.toString());
+            }
 
             // this line cleans the table for a second and the components have to be created again (clean)
             this.rows = [];

--- a/src/components/InternalTransactionTable.vue
+++ b/src/components/InternalTransactionTable.vue
@@ -101,7 +101,7 @@ export default {
                 if (typeof pag === 'number') {
                     page = pag;
                 } else if (typeof pag === 'string') {
-                    // we also allow to pass a string of two numbers: [page, rowsPerPage]
+                    // we also allow to pass a string of two numbers: 'page,rowsPerPage'
                     const [p, s] = pag.split(',');
                     page = p;
                     size = s;
@@ -142,7 +142,6 @@ export default {
                     page: `${page},${rowsPerPage}`,
                 },
             });
-
         },
         async onRequest(props) {
             this.loading = true;

--- a/src/components/InternalTransactionTable.vue
+++ b/src/components/InternalTransactionTable.vue
@@ -1,0 +1,280 @@
+<script>
+import BlockField from 'components/BlockField';
+import DateField from 'components/DateField';
+import TransactionField from 'components/TransactionField';
+import MethodField from 'components/MethodField';
+import { formatWei } from 'src/lib/utils';
+import { TRANSFER_SIGNATURES } from 'src/lib/abi/signature/transfer_signatures';
+import InternalTxns from 'components/Transaction/InternalTxns';
+
+export default {
+    name: 'InternalTransactionTable',
+    components: {
+        TransactionField,
+        DateField,
+        BlockField,
+        MethodField,
+        InternalTxns,
+    },
+    props: {
+        title: {
+            type: String,
+            required: true,
+        },
+        filter: {
+            type: Object,
+            default: () => ({}),
+        },
+        initialPageSize: {
+            type: Number,
+            default: 1,
+        },
+    },
+    data() {
+        const columns = [
+            {
+                name: 'hash',
+                label: '',
+                align: 'left',
+            },
+            {
+                name: 'block',
+                label: '',
+                align: 'left',
+            },
+            {
+                name: 'date',
+                label: '',
+                align: 'left',
+            },
+            {
+                name: 'method',
+                label: '',
+                align: 'left',
+            },
+            {
+                name: 'int_txns',
+                label: '',
+                align: 'right',
+            },
+        ];
+
+        return {
+            rows: [],
+            columns,
+            transactions: [],
+            pageSize: this.initialPageSize,
+            total: null,
+            loading: false,
+            pagination: {
+                sortBy: 'date',
+                descending: true,
+                page: 1,
+                rowsPerPage: 10,
+                rowsNumber: 0,
+            },
+            showDateAge: true,
+        };
+    },
+    async created() {
+        // initialization of the translated texts
+        this.columns[0].label = this.$t('components.tx_hash');
+        this.columns[1].label = this.$t('components.block');
+        this.columns[2].label = this.$t('components.date');
+        this.columns[3].label = this.$t('components.method');
+        this.columns[4].label = this.$t('components.internal_txns');
+    },
+    mounted() {
+        this.onRequest({
+            pagination: this.pagination,
+        });
+    },
+    methods: {
+        async onRequest(props) {
+            this.loading = true;
+
+            // this line cleans the table for a second and the components have to be created again (clean)
+            this.rows = [];
+
+            const { page, rowsPerPage, sortBy, descending } = props.pagination;
+            let result = await this.$evmEndpoint.get(this.getPath(props));
+
+            if (this.total === null) {
+                this.pagination.rowsNumber = result.data.total.value;
+            }
+
+            this.pagination.page = page;
+            this.pagination.rowsPerPage = rowsPerPage;
+            this.pagination.sortBy = sortBy;
+            this.pagination.descending = descending;
+
+            this.transactions = [...result.data.transactions];
+            this.rows = this.transactions;
+
+            for (const transaction of this.transactions) {
+                try {
+                    transaction.transfer = false;
+                    transaction.value = formatWei(transaction.value.toLocaleString(0, { useGrouping: false }), 18);
+                    if (transaction.input_data === '0x') {
+                        continue;
+                    }
+                    if(!transaction.to) {
+                        continue;
+                    }
+
+                    const contract = await this.$contractManager.getContract(
+                        transaction.to,
+                    );
+
+                    if (!contract) {
+                        continue;
+                    }
+
+                    const parsedTransaction = await contract.parseTransaction(
+                        transaction.input_data,
+                    );
+                    if (parsedTransaction) {
+                        transaction.parsedTransaction = parsedTransaction;
+                        transaction.contract = contract;
+                    }
+                    // Get ERC20 transfer from main function call
+                    let signature = transaction.input_data.substring(0, 10);
+                    if (
+                        signature &&
+                        TRANSFER_SIGNATURES.includes(signature) &&
+                        transaction.parsedTransaction.args['amount']
+                    ) {
+                        let token = await this.$contractManager.getTokenData(transaction.to, 'erc20');
+                        if(transaction.contract && token && token.decimals){
+                            transaction.transfer = {
+                                'value': `${formatWei(transaction.parsedTransaction.args['amount'], token.decimals)}`,
+                                'symbol': token.symbol,
+                            };
+                        }
+                    }
+                } catch (e) {
+                    console.error(
+                        `Failed to parse data for transaction, error was: ${e.message}`,
+                    );
+                    // notifiy user
+                    this.$q.notify({
+                        message: this.$t('components.failed_to_parse_transaction', { message: e.message }),
+                        color: 'negative',
+                        position: 'top',
+                        timeout: 5000,
+                    });
+                }
+            }
+            this.rows = this.transactions;
+            this.loading = false;
+        },
+        getPath(props) {
+            const { page, rowsPerPage, descending } = props.pagination;
+            let path = `/v2/evm/get_transactions?limit=${
+                rowsPerPage === 0 ? 500 : rowsPerPage
+            }`;
+            const filter = Object.assign({}, this.filter ? this.filter : {});
+            if (filter.address) {
+                path += `&address=${filter.address}`;
+            }
+
+            if (filter.block) {
+                path += `&block=${filter.block}`;
+            }
+
+            if (filter.hash) {
+                path += `&hash=${filter.hash}`;
+            }
+
+            path += `&skip=${(page - 1) * rowsPerPage}`;
+            path += `&sort=${descending ? 'desc' : 'asc'}`;
+
+            return path;
+        },
+        toggleDateFormat() {
+            this.showDateAge = !this.showDateAge;
+        },
+    },
+};
+</script>
+
+<template>
+<q-table
+    v-model:pagination="pagination"
+    :rows="rows"
+    :row-key="row => row.hash"
+    :columns="columns"
+    :loading="loading"
+    :rows-per-page-options="[10, 20, 50]"
+    flat
+    @request="onRequest"
+>
+    <template v-slot:header="props">
+        <q-tr :props="props">
+            <q-th v-for="col in props.cols" :key="col.name" :props="props">
+                <div :class="[ 'u-flex--center-y', { 'u-flex--right': col.align === 'right' } ]" >
+                    {{ col.label }}
+                    <template v-if="col.name === 'date'">
+                        <q-icon
+                            class="info-icon"
+                            name="fas fa-info-circle"
+                            @click="toggleDateFormat"
+                        >
+                            <q-tooltip anchor="bottom middle" self="bottom middle" :offset="[0, 36]">
+                                {{ $t('components.click_to_change_format') }}
+                            </q-tooltip>
+                        </q-icon>
+                    </template>
+                    <template v-if="col.name === 'method'">
+                        <q-icon class="info-icon" name="fas fa-info-circle" />
+                        <q-tooltip anchor="bottom middle" self="top middle" max-width="10rem">
+                            {{ $t('components.executed_based_on_decoded_data') }}
+                        </q-tooltip>
+                    </template>
+                </div>
+            </q-th>
+            <q-td auto-width/>
+        </q-tr>
+    </template>
+    <template v-slot:body="props">
+        <q-tr :props="props">
+            <q-td key="hash" :props="props">
+                <TransactionField :transaction-hash="props.row.hash"/>
+            </q-td>
+            <q-td key="block" :props="props">
+                <BlockField :block="props.row.block"/>
+            </q-td>
+            <q-td key="date" :props="props">
+                <DateField :epoch="props.row.epoch" :force-show-age="showDateAge"/>
+            </q-td>
+            <q-td key="method" :props="props">
+                <MethodField v-if="props.row.parsedTransaction" :trx="props.row" :shortenName="true"/>
+            </q-td>
+            <q-td key="int_txns" :props="props">
+                <span v-if="props.row.itxs.length > 0">
+                    <b> {{ $t('components.n_internal_txns', {amount: props.row.itxs.length} ) }} </b>
+                </span>
+                <span v-else>{{ $t('components.none') }}</span>
+            </q-td>
+            <q-td auto-width>
+                <q-icon
+                    v-if="props.row.itxs.length > 0"
+                    :name="props.expand ? 'expand_more' : 'expand_less'"
+                    size="sm"
+                    @click="props.expand = !props.expand"
+                />
+            </q-td>
+        </q-tr>
+        <q-tr
+            v-show="!props.expand"
+            v-if="props.row.itxs.length > 0"
+            :props="props"
+            class="q-virtual-scroll--with-prev"
+        >
+            <q-td colspan="100%">
+                <InternalTxns :itxs="props.row.itxs"/>
+            </q-td>
+        </q-tr>
+    </template>
+</q-table>
+</template>

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -184,6 +184,9 @@ export default {
         value: 'Value',
     },
     components: {
+        internal_txns: 'Internal Transactions',
+        n_internal_txns: '{ amount } internal transactions',
+        none: 'None',
         verify_prompt: 'This contract has not been verified.  Would you like to upload the contract(s) and metadata to verify source now?',
         verify_contract: 'Verify Contract',
         search_evm_address_failed: 'Search for EVM address linked to { accountName } native account failed. You can create one at wallet.telos.net',

--- a/src/i18n/es-es/index.js
+++ b/src/i18n/es-es/index.js
@@ -184,6 +184,9 @@ export default {
         value: 'Valor',
     },
     components: {
+        internal_txns: 'Transacciones internas',
+        n_internal_txns: '{ amount } transacciones internas',
+        none: 'Ninguno',
         verify_prompt: 'Este contrato no ha sido verificado. ¿Le gustaría cargar el (los) contrato (s) y los metadatos para verificar el código fuente ahora?',
         verify_contract: 'Verificar contrato',
         search_evm_address_failed: 'La búsqueda de la dirección EVM vinculada a la cuenta nativa { accountName } falló. Puede crear una en wallet.telos.net',

--- a/src/i18n/pt-br/index.js
+++ b/src/i18n/pt-br/index.js
@@ -184,6 +184,9 @@ export default {
         value: 'Valor',
     },
     components: {
+        internal_txns: 'Transações internas',
+        n_internal_txns: '{ amount } transações internas',
+        none: 'Nenhum',
         verify_prompt: 'Este contrato ainda não foi verificado. Você gostaria de carregar o(s) contrato(s) e os metadados para verificar o código-fonte agora?',
         verify_contract: 'Verificar contrato',
         search_evm_address_failed: 'A busca pelo endereço EVM vinculado à conta nativa { accountName } falhou. Você pode criar uma em wallet.telos.net',

--- a/src/pages/AccountAddress.vue
+++ b/src/pages/AccountAddress.vue
@@ -1,7 +1,9 @@
+<!-- eslint-disable vue/no-unused-components -->
 <script>
 import { toChecksumAddress } from 'src/lib/utils';
 import Web3 from 'web3';
 import TransactionTable from 'components/TransactionTable';
+import InternalTransactionTable from 'components/InternalTransactionTable';
 import TransferTable from 'components/TransferTable';
 import TokenList from 'components/TokenList';
 import ConfirmationDialog from 'components/ConfirmationDialog';
@@ -15,6 +17,7 @@ const web3 = new Web3();
 
 const tabs = {
     transactions: '#transactions',
+    int_transactions: '#int_transactions',
     erc20_transfers: '#erc20',
     erc721_transfers: '#erc721',
     erc1155_transfers: '#erc1155',
@@ -33,6 +36,7 @@ export default {
         TokenList,
         TransactionField,
         TransactionTable,
+        InternalTransactionTable,
         TransferTable,
     },
     data() {
@@ -243,6 +247,13 @@ export default {
                 :label="$t('pages.transactions')"
             />
             <q-route-tab
+                name="int_transactions"
+                :to="{ hash: '#int_transactions' }"
+                exact
+                replace
+                :label="$t('pages.internal_txns')"
+            />
+            <q-route-tab
                 name="erc20_transfers"
                 :to="{ hash: '#erc20' }"
                 exact
@@ -289,6 +300,9 @@ export default {
             >
                 <q-tab-panel name="transactions">
                     <TransactionTable :title="address" :filter="{address}"/>
+                </q-tab-panel>
+                <q-tab-panel name="int_transactions">
+                    <InternalTransactionTable :title="address" :filter="{address}"/>
                 </q-tab-panel>
                 <q-tab-panel name="erc20_transfers">
                     <TransferTable

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -17,6 +17,7 @@ const routes = [
             {
                 path: '',
                 name: 'address',
+                props: route => ({ page: route.query.page, pagesize: route.query.pagesize }),
                 component: () => import('pages/AccountAddress.vue'),
             },
         ],


### PR DESCRIPTION
# Fixes #226

## Description
This PR adds a new tab on the account page to show the same transaction pagination but focused on showing the internal transactions for each parent transaction.

As default behavior, the internal transactions data is visible for all transactions but the user can close and reopen the section for each transaction individually using a switcher on the right of the transaction header.

## Test scenarios
- Normal navigation
   - Go to [this address account page](https://deploy-preview-346--dev-mainnet-teloscan.netlify.app/address/0xa30b5e3c8Fee56C135Aecb733cd708cC31A5657a)
   - Press the Internal Transactions Tab
   - You should see the first page of transactions (currently all of them have zero int-trxs)
   - change the page until you see a transaction with some internal transactions
   - close ad reopen the content section of any transaction (using the switcher on the right of the header)
- Pagination by url: access directly
   - Go directly to the [second page](https://deploy-preview-346--dev-mainnet-teloscan.netlify.app/address/0xa30b5e3c8Fee56C135Aecb733cd708cC31A5657a?page=2,20#int_transactions) with 20 rows per page
   - You should be on the second page and see 20 rows
- Pagination by url: back button
   - Go to the internal [transaction tab](https://deploy-preview-346--dev-mainnet-teloscan.netlify.app/address/0xa30b5e3c8Fee56C135Aecb733cd708cC31A5657a#int_transactions)
   - Navigate to several pages forward
   - Then navigate away from the current table
   - press the back button from your browser
   - You should see the last pagination in the internal transaction tab


# Screenshots

![image](https://user-images.githubusercontent.com/4420760/216056076-696bf078-4947-445c-b1ae-204d4f947d6e.png)

![image](https://user-images.githubusercontent.com/4420760/216056119-488b0c49-f587-4642-92a4-03629465dc81.png)

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
