### PR TITLE
#354 | Fix header advanced menu

### DIFF
--- a/src/components/header/AppHeader.vue
+++ b/src/components/header/AppHeader.vue
@@ -173,23 +173,22 @@ export default {
 
             <q-separator class="c-header__menu-separator"/>
 
-            <li class="c-header__menu-li">
+            <li
+                class="c-header__menu-li"
+                tabindex="0"
+                aria-label="expand advanced menu"
+                role="menuitem"
+                aria-haspopup="menu"
+                @keydown.enter="advancedMenuExpanded = !advancedMenuExpanded"
+                @click="advancedMenuExpanded = !advancedMenuExpanded"
+            >
                 <q-icon
                     name="code"
                     class="c-header__menu-item-icon"
                     size="sm"
-                    @click="advancedMenuExpanded = !advancedMenuExpanded"
                 />
                 <div class="c-header__advanced-container">
-                    <div
-                        class="c-header__advanced-container-header"
-                        tabindex="0"
-                        aria-label="expand advanced menu"
-                        role="menuitem"
-                        aria-haspopup="menu"
-                        @keydown.enter="advancedMenuExpanded = !advancedMenuExpanded"
-                        @click="advancedMenuExpanded = !advancedMenuExpanded"
-                    >
+                    <div class="c-header__advanced-container-header">
                         {{ $t('components.header.advanced') }}
 
                         <q-icon


### PR DESCRIPTION
# Fixes #354 

## Description
The advanced menu would sometimes not open on click because the click listener was on the incorrect element; if the cursor was on the edge of the menu element, clicking it would have no effect even though the hover style would appear.

## Test scenarios
- first reproduce the issue in prod: go to https://teloscan.io
- hover over the Advanced menu element in the header and click the corner of the highlighted box
    - see that the menu does not appear
- go to https://deploy-preview-366--dev-mainnet-teloscan.netlify.app/
- follow the same steps to reproduce
    - the advanced menu should appear on click

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
