### PR TITLE
Hotifx/block navigation data reset

### DIFF
--- a/src/css/dataCard.sass
+++ b/src/css/dataCard.sass
@@ -6,7 +6,7 @@
   gap: 10px
   .dataCardItem
     background: #0000001e
-    width: 7rem
+    min-width: 8rem
     display: flex
     flex-direction: column
     align-items: center

--- a/src/css/dataCard.sass
+++ b/src/css/dataCard.sass
@@ -3,6 +3,7 @@
 
 .dataCardsContainer
   display: flex
+  flex-wrap: wrap
   gap: 10px
   .dataCardItem
     background: #0000001e
@@ -12,7 +13,8 @@
     align-items: center
     justify-content: center
     border-radius: 6px
-    padding:20px
+    padding: 20px
+    margin: 4px
 
   .dataCardTile
     color: $white

--- a/src/css/dataCard.sass
+++ b/src/css/dataCard.sass
@@ -7,7 +7,7 @@
   gap: 10px
   .dataCardItem
     background: #0000001e
-    min-width: 7.5rem
+    min-width: 8rem
     display: flex
     flex-direction: column
     align-items: center

--- a/src/css/dataCard.sass
+++ b/src/css/dataCard.sass
@@ -7,7 +7,7 @@
   gap: 10px
   .dataCardItem
     background: #0000001e
-    min-width: 8rem
+    min-width: 7.5rem
     display: flex
     flex-direction: column
     align-items: center

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -178,7 +178,6 @@ export function getClientIsApple() {
  * @return {string}
  */
 export function getFormattedUtcOffset(date) {
-    debugger;
     const pad = value => value < 10 ? '0' + value : value;
     const sign = (date.getTimezoneOffset() > 0) ? '-' : '+';
     const offset = Math.abs(date.getTimezoneOffset());

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -178,6 +178,7 @@ export function getClientIsApple() {
  * @return {string}
  */
 export function getFormattedUtcOffset(date) {
+    debugger;
     const pad = value => value < 10 ? '0' + value : value;
     const sign = (date.getTimezoneOffset() > 0) ? '-' : '+';
     const offset = Math.abs(date.getTimezoneOffset());

--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -76,7 +76,7 @@ export default {
                     <div v-if="blockData" class="dataCardData">
                         {{ parseInt(blockData.gasUsed, 16) }}
                     </div>
-                    <div v-else class="dataCardData">&nbsp;</div>
+                    <div v-else class="dataCardData">0</div>
                 </div>
                 <div class="dataCardItem">
                     <div class="dataCardTile">
@@ -85,13 +85,12 @@ export default {
                     <div v-if="blockData" class="dataCardData">
                         {{ blockData.transactions.length }}
                     </div>
-                    <div v-else class="dataCardData">&nbsp;</div>
+                    <div v-else class="dataCardData">0</div>
                 </div>
                 <div v-if="blockData" class="dataCardItem">
                     <DateField :epoch="parseInt(blockData.timestamp, 16)"/>
                 </div>
-                <div v-else class="dataCardItem">
-                </div>
+                <div v-else class="dataCardItem"></div>
             </div>
         </div>
     </div>

--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -134,7 +134,7 @@ export default {
         background: linear-gradient(#252a5e 17.19%, #2d4684 65.83%, transparent 100%)
     .row.justify-between.q-mb-lg
         div
-            &:first-child
+            &:last-child
                 text-align: center
                 width: 100%
     .dataCardsContainer

--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -101,6 +101,8 @@ export default {
 </template>
 
 <style scoped lang="sass">
+.dataCardData
+    height: 40px
 .inline
     display: inline-flex
     align-items: center

--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -34,6 +34,7 @@ export default {
                 method: 'eth_getBlockByNumber',
                 params: [`0x${parseInt(this.block).toString(16)}`, false],
             });
+            debugger;
             this.blockData = blockResponse.result;
         },
         prevBlock() {
@@ -76,7 +77,7 @@ export default {
                     <div v-if="blockData" class="dataCardData">
                         {{ parseInt(blockData.gasUsed, 16) }}
                     </div>
-                    <div v-else>-</div>
+                    <div v-else class="dataCardData">-</div>
                 </div>
                 <div class="dataCardItem">
                     <div class="dataCardTile">
@@ -85,18 +86,16 @@ export default {
                     <div v-if="blockData" class="dataCardData">
                         {{ blockData.transactions.length }}
                     </div>
-                    <div v-else>-</div>
+                    <div v-else class="dataCardData">-</div>
                 </div>
                 <div v-if="blockData" class="dataCardItem">
-                    <div class="dataCardTile">
-                        <DateField :epoch="blockData.timestamp"/>
-                    </div>
+                    <DateField :epoch="parseInt(blockData.timestamp, 16)"/>
                 </div>
                 <div v-else class="dataCardItem">
                     <div class="dataCardTile">
-                        <div>Time</div>
+                        Time
                     </div>
-                    <div>-</div>
+                    <div class="dataCardData">-</div>
                 </div>
             </div>
         </div>

--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -87,10 +87,10 @@ export default {
                     </div>
                     <div v-else class="dataCardData">0</div>
                 </div>
-                <div v-if="blockData" class="dataCardItem">
+                <div v-if="blockData" class="dataCardItem time-stamp">
                     <DateField :epoch="parseInt(blockData.timestamp, 16)"/>
                 </div>
-                <div v-else class="dataCardItem"></div>
+                <div v-else class="dataCardItem time-stamp"></div>
             </div>
         </div>
     </div>
@@ -132,11 +132,10 @@ export default {
 @media only screen and (max-width: 768px)
     .pageContainer
         background: linear-gradient(#252a5e 17.19%, #2d4684 65.83%, transparent 100%)
-    .row.justify-between.q-mb-lg
-        div
-            &:last-child
-                text-align: center
-                width: 100%
+    .time-stamp
+        text-align: center
+        width: 100%
+        min-height: 38px
     .dataCardsContainer
         width: 100%
         margin-top: 30px

--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -34,7 +34,6 @@ export default {
                 method: 'eth_getBlockByNumber',
                 params: [`0x${parseInt(this.block).toString(16)}`, false],
             });
-            debugger;
             this.blockData = blockResponse.result;
         },
         prevBlock() {

--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -109,6 +109,7 @@ export default {
 
 .block-container
     &__block-number
+        width: 100px
         font-size: 16px
         margin-right: 6px
     &__block-navigation

--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -37,10 +37,15 @@ export default {
             this.blockData = blockResponse.result;
         },
         prevBlock() {
+            this.resetBlockData();
             this.$router.push({ name: 'block', params: { block: parseInt(this.block) - 1 } });
         },
         nextBlock() {
+            this.resetBlockData();
             this.$router.push({ name: 'block', params: { block: parseInt(this.block) + 1 } });
+        },
+        resetBlockData() {
+            this.blockData = null;
         },
     },
 };
@@ -63,27 +68,35 @@ export default {
                     </div>
                 </div>
             </div>
-            <div v-if="blockData" class="dataCardsContainer">
+            <div class="dataCardsContainer">
                 <div class="dataCardItem">
                     <div class="dataCardTile">
                         {{ $t('pages.gas_used') }}
                     </div>
-                    <div class="dataCardData">
+                    <div v-if="blockData" class="dataCardData">
                         {{ parseInt(blockData.gasUsed, 16) }}
                     </div>
+                    <div v-else>-</div>
                 </div>
                 <div class="dataCardItem">
                     <div class="dataCardTile">
                         {{ $t('pages.transactions') }}
                     </div>
-                    <div class="dataCardData">
-                        {{ blockData.transactions.length || 0 }}
+                    <div v-if="blockData" class="dataCardData">
+                        {{ blockData.transactions.length }}
                     </div>
+                    <div v-else>-</div>
                 </div>
-                <div class="dataCardItem">
+                <div v-if="blockData" class="dataCardItem">
                     <div class="dataCardTile">
                         <DateField :epoch="blockData.timestamp"/>
                     </div>
+                </div>
+                <div v-else class="dataCardItem">
+                    <div class="dataCardTile">
+                        <div>Time</div>
+                    </div>
+                    <div>-</div>
                 </div>
             </div>
         </div>

--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -76,7 +76,7 @@ export default {
                     <div v-if="blockData" class="dataCardData">
                         {{ parseInt(blockData.gasUsed, 16) }}
                     </div>
-                    <div v-else class="dataCardData">-</div>
+                    <div v-else class="dataCardData">&nbsp;</div>
                 </div>
                 <div class="dataCardItem">
                     <div class="dataCardTile">
@@ -85,7 +85,7 @@ export default {
                     <div v-if="blockData" class="dataCardData">
                         {{ blockData.transactions.length }}
                     </div>
-                    <div v-else class="dataCardData">-</div>
+                    <div v-else class="dataCardData">&nbsp;</div>
                 </div>
                 <div v-if="blockData" class="dataCardItem">
                     <DateField :epoch="parseInt(blockData.timestamp, 16)"/>

--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -91,10 +91,6 @@ export default {
                     <DateField :epoch="parseInt(blockData.timestamp, 16)"/>
                 </div>
                 <div v-else class="dataCardItem">
-                    <div class="dataCardTile">
-                        Time
-                    </div>
-                    <div class="dataCardData">-</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- persist block data divs
- reset to '-' data value and 'Time' header for timestamp 
- fix utc offset for timestamp conversion (NaN on production)