### PR TITLE
fix: redirect /endpoints to /health

### DIFF
--- a/src/pages/HealthPage.vue
+++ b/src/pages/HealthPage.vue
@@ -1,10 +1,7 @@
-<script>
+<script lang="ts" setup>
 import Endpoints from 'components/Health/Endpoints.vue';
 import Monitor from 'components/Health/Monitor.vue';
-export default {
-    name: 'HealthPage',
-    components: { Endpoints, Monitor },
-};
+
 </script>
 
 <template>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -72,8 +72,14 @@ const routes = [
     },
     {
         path: '/health',
+        name: 'health',
         component: () => import('layouts/MainLayout.vue'),
-        children: [{ path: '', component: () => import('pages/Health.vue') }],
+        children: [{ path: '', component: () => import('pages/HealthPage.vue') }],
+    },
+    {
+        path: '/endpoints',
+        // eslint-disable-next-line no-unused-vars
+        redirect: to => ({ path: '/health' }),
     },
     {
         path: '/:catchAll(.*)*',


### PR DESCRIPTION
# Fixes #454 

## Description
see issue 

## Test scenarios

- visit https://deploy-preview-453--teloscan.netlify.app/endpoints
- should redirect to https://deploy-preview-453--teloscan.netlify.app/health (/endpoints -> /health)

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have tested for mobile functionality and responsiveness

