### PR TITLE
handle wallet address change gracefully do not require reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "oreid-js": "^4.7.1",
     "oreid-webpopup": "^2.4.0",
     "quasar": "2",
+    "rxjs": "^7.8.0",
     "ual-anchor": "^1.0.0",
     "ual-ledger": "^0.3.0",
     "ual-wombat": "^0.3.3",

--- a/src/antelope/mocks/AccountStore.ts
+++ b/src/antelope/mocks/AccountStore.ts
@@ -54,6 +54,8 @@ class AccountStore {
     async loginEVM({ authenticator, network }: LoginEVMActionData): Promise<boolean> {
         currentAuthenticator = authenticator;
         currentAccount = await authenticator.login(network);
+        const account = useAccountStore().getAccount(authenticator.label);
+        getAntelope().events.onLoggedIn.next(account);
         return true;
     }
 
@@ -62,6 +64,7 @@ class AccountStore {
         currentAuthenticator.logout();
         currentAuthenticator = {} as EVMAuthenticator;
         currentAccount = null;
+        getAntelope().events.onLoggedOut.next();
     }
 
     get loggedAccount() {

--- a/src/antelope/mocks/AntelopeConfig.ts
+++ b/src/antelope/mocks/AntelopeConfig.ts
@@ -5,6 +5,8 @@ import { EVMAuthenticator } from 'src/antelope/wallets/authenticators/EVMAuthent
 import { AntelopeError, AntelopeErrorPayload } from 'src/antelope/types';
 import { App } from 'vue';
 import { Authenticator } from 'universal-authenticator-library';
+import { Subject } from 'rxjs';
+import { AccountModel } from 'src/antelope/mocks/AccountStore';
 
 export interface ComplexMessage {
     tag: string,
@@ -286,9 +288,14 @@ export class AntelopeConfig {
 
 const config = new AntelopeConfig();
 const wallets = new AntelopeWallets();
+const events = {
+    onLoggedIn: new Subject<AccountModel>(),
+    onLoggedOut: new Subject<void>(),
+};
 const Antelope = {
     config,
     wallets,
+    events,
 };
 
 export const getAntelope = () => Antelope;

--- a/src/antelope/wallets/init.ts
+++ b/src/antelope/wallets/init.ts
@@ -87,11 +87,5 @@ export function initAntelope(app: App) {
     ant.wallets.addEVMAuthenticator(new SafePalAuth());
     ant.wallets.addEVMAuthenticator(new BraveAuth());
 
-    // FIXME: remove this code
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).antelope = ant;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).ant = ant;
-
 }
 

--- a/src/antelope/wallets/init.ts
+++ b/src/antelope/wallets/init.ts
@@ -87,4 +87,11 @@ export function initAntelope(app: App) {
     ant.wallets.addEVMAuthenticator(new SafePalAuth());
     ant.wallets.addEVMAuthenticator(new BraveAuth());
 
+    // FIXME: remove this code
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).antelope = ant;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).ant = ant;
+
 }
+

--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -5,21 +5,16 @@
 import detectEthereumProvider from '@metamask/detect-provider';
 import { defineComponent } from 'vue';
 import { mapGetters, mapMutations } from 'vuex';
-import { ethers } from 'ethers';
 import {
-    WEI_PRECISION,
     LOGIN_EVM,
     LOGIN_NATIVE,
-    PROVIDER_WEB3_INJECTED,
     PROVIDER_TELOS_CLOUD,
     PROVIDER_WALLET_CONNECT,
     PROVIDER_BRAVE,
     PROVIDER_METAMASK,
-    DEFAULT_CHAIN_ID,
     LOGIN_DATA_KEY,
 } from 'src/lib/utils';
-import { tlos } from 'src/lib/logos';
-import { CURRENT_CONTEXT, getAntelope, useAccountStore, useChainStore } from 'src/antelope/mocks';
+import { AccountModel, CURRENT_CONTEXT, EvmAccountModel, getAntelope, useAccountStore, useChainStore } from 'src/antelope/mocks';
 import { Authenticator } from 'universal-authenticator-library';
 import InlineSvg from 'vue-inline-svg';
 import { isTodayBeforeTelosCloudDown } from 'src/App.vue';
@@ -64,6 +59,19 @@ export default defineComponent({
     async mounted() {
         await this.detectProvider();
         this.detectMobile();
+
+        // On login we must set the address and record the provider
+        getAntelope().events.onLoggedIn.subscribe((account: AccountModel) => {
+            const evm_account = account as EvmAccountModel;
+            const address = evm_account.account;
+            const pr_name = evm_account.authenticator.getName();
+            this.setLogin({ address });
+
+            localStorage.setItem(LOGIN_DATA_KEY, JSON.stringify({
+                type: LOGIN_EVM,
+                provider: pr_name,
+            }));
+        });
 
         const loginData = localStorage.getItem(LOGIN_DATA_KEY);
         if (!loginData) {
@@ -110,56 +118,8 @@ export default defineComponent({
         getLoginDisplay() {
             return this.isNative ? this.nativeAccount : `0x...${this.address.slice(this.address.length - 4)}`;
         },
-        connect() {
-            this.showLogin = true;
-        },
-        disconnect() {
-            if (this.isNative) {
-                const loginData = localStorage.getItem(LOGIN_DATA_KEY);
-                if (!loginData) {
-                    return;
-                }
-
-                const loginObj = JSON.parse(loginData);
-                const wallet = this.authenticators.find((a: { getName: () => any; }) => a.getName() === loginObj.provider);
-                wallet?.logout();
-            }
-
-            this.setLogin({});
-            localStorage.removeItem(LOGIN_DATA_KEY);
-            this.$providerManager.setProvider(null);
-        },
         goToAddress() {
             this.$router.push(`/address/${this.address}`);
-        },
-        async injectedWeb3Login() {
-            const address = await this.getInjectedAddress();
-            if (address) {
-                this.setLogin({
-                    address,
-                });
-                let provider = this.getInjectedProvider();
-                let checkProvider = new ethers.providers.Web3Provider(provider);
-                this.$providerManager.setProvider(provider);
-                const { chainId } = await checkProvider.getNetwork();
-                localStorage.setItem(LOGIN_DATA_KEY, JSON.stringify({
-                    type: LOGIN_EVM,
-                    provider: PROVIDER_WEB3_INJECTED,
-                    chain: chainId,
-                }));
-                provider.on('chainChanged', (newNetwork: number) => {
-                    if(newNetwork !== chainId){
-                        this.setLogin({});
-                        this.$providerManager.setProvider(null);
-                    }
-                });
-                provider.on('accountsChanged', (accounts: any[]) => {
-                    this.setLogin({
-                        address: accounts[0],
-                    });
-                });
-            }
-            this.$emit('hide');
         },
         async ualLogin(wallet: Authenticator, account?: string) {
             await wallet.init();
@@ -187,96 +147,6 @@ export default defineComponent({
                 localStorage.setItem(LOGIN_DATA_KEY, JSON.stringify({ type: LOGIN_NATIVE, provider: wallet.getName() }));
             }
             this.$emit('hide');
-        },
-        async getInjectedAddress() {
-            const provider = this.getInjectedProvider();
-            let checkProvider: ethers.providers.Web3Provider | undefined = new ethers.providers.Web3Provider(provider);
-
-            const newProviderInstance = await this.ensureCorrectChain(checkProvider);
-            if(newProviderInstance){
-                checkProvider = newProviderInstance;
-            }
-            const accounts = await checkProvider.listAccounts();
-            if (accounts.length > 0) {
-                checkProvider = await this.ensureCorrectChain(checkProvider);
-                return accounts[0];
-            } else {
-                const accessGranted = await provider.request({ method: 'eth_requestAccounts' });
-                if (accessGranted.length < 1) {
-                    return false;
-                }
-
-                checkProvider = await this.ensureCorrectChain(checkProvider);
-                return accessGranted[0];
-            }
-        },
-        async ensureCorrectChain(checkProvider: ethers.providers.Web3Provider) {
-            const { chainId } = await checkProvider.getNetwork();
-            if (+chainId !== +(process.env.NETWORK_EVM_CHAIN_ID ?? DEFAULT_CHAIN_ID)) {
-                await this.switchChainInjected();
-                const provider = this.getInjectedProvider();
-                return new ethers.providers.Web3Provider(provider);
-            }
-        },
-        getInjectedProvider() {
-            // window.ethereum.isMetaMask includes Brave Wallet
-            const provider = window.ethereum.isMetaMask || window.ethereum.isCoinbaseWallet ?
-                window.ethereum :
-                null;
-            if (!provider) {
-                this.$q.notify({
-                    position: 'top',
-                    message: this.$t('components.no_provider_found'),
-                    timeout: 6000,
-                });
-            }
-            return provider;
-        },
-        async switchChainInjected() {
-            const provider = this.getInjectedProvider();
-
-            if (provider) {
-                const chainId = parseInt(process.env.NETWORK_EVM_CHAIN_ID || DEFAULT_CHAIN_ID, 10);
-                const chainIdParam = `0x${chainId.toString(16)}`;
-                const mainnet = chainId === 40;
-                try {
-                    await provider.request({
-                        method: 'wallet_switchEthereumChain',
-                        params: [{ chainId: chainIdParam }],
-                    });
-                    return true;
-                } catch (e) {
-                    const chainNotAddedCodes = [
-                        4902,
-                        -32603, // https://github.com/MetaMask/metamask-mobile/issues/2944
-                    ];
-
-                    if (chainNotAddedCodes.includes((e as {code:number}).code)) {  // 'Chain <hex chain id> hasn't been added'
-                        try {
-                            await provider.request({
-                                method: 'wallet_addEthereumChain',
-                                params: [{
-                                    chainId: chainIdParam,
-                                    chainName: `Telos EVM ${mainnet ? 'Mainnet' : 'Testnet'}`,
-                                    nativeCurrency: {
-                                        name: 'Telos',
-                                        symbol: 'TLOS',
-                                        decimals: WEI_PRECISION,
-                                    },
-                                    rpcUrls: [`https://${mainnet ? 'mainnet' : 'testnet'}.telos.net/evm`],
-                                    blockExplorerUrls: [`https://${mainnet ? '' : 'testnet.'}teloscan.io`],
-                                    iconUrls: [tlos],
-                                }],
-                            });
-                            return true;
-                        } catch (e) {
-                            console.error(e);
-                        }
-                    }
-                }
-            } else {
-                return false;
-            }
         },
         getIconForWallet(wallet: { getName: () => string; getStyle: () => { icon: string; }; }) {
             if (wallet.getName() === 'wombat') {

--- a/src/components/header/AppHeader.vue
+++ b/src/components/header/AppHeader.vue
@@ -8,7 +8,7 @@ import LanguageSwitcherModal from 'components/header/LanguageSwitcherModal.vue';
 import LoginModal from 'components/LoginModal.vue';
 import LoginStatus from 'components/header/LoginStatus.vue';
 import { RouteLocationRaw } from 'vue-router';
-import { useAccountStore } from 'src/antelope';
+import { getAntelope, useAccountStore } from 'src/antelope';
 import { defineComponent } from 'vue';
 
 export default defineComponent({
@@ -73,6 +73,13 @@ export default defineComponent({
             }
         },
         logout() {
+            useAccountStore().logout();
+        },
+    },
+    async mounted() {
+
+        // On login we must set the address and record the provider
+        getAntelope().events.onLoggedOut.subscribe(() => {
             const loginData = localStorage.getItem('loginData');
             if (this.isNative) {
                 if (!loginData) {
@@ -83,11 +90,10 @@ export default defineComponent({
                 const wallet = this.$ual.getAuthenticators().availableAuthenticators.find(a => a.getName() === loginObj.provider);
                 wallet?.logout();
             }
-            useAccountStore().logout();
             this.setLogin({});
             localStorage.removeItem('loginData');
             this.$providerManager.setProvider(null);
-        },
+        });
     },
 });
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10453,7 +10453,7 @@ rxjs@^6.5.3, rxjs@^6.6.3:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.5.5:
+rxjs@^7.5.5, rxjs@^7.8.0:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
   integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==


### PR DESCRIPTION
# Fixes #490

## Description
The PR includes three different parts:
- removal of the legacy code (related to the login process and not part of the Antelope Wallets solution)
- partial migration of some Antelope events (onLoggedIn and onLoggedOut)
- refactor the previous login and logout process by subscribing to those events

With those changes, now the Antelope Wallets are the only way to log in and out, and that makes the internal subscription to the provider's `accountChange` event, to actually work. Because now using the Antelope library to log in to the newly detected account, will end up in a handler subscribed to the onLoggedIn event, and therefore the site will reflect the new state.

## Test scenarios
See the video: [Metamask-change-account--Teloscan.webm](https://github.com/telosnetwork/teloscan/assets/4420760/2b2e775d-0e34-4f8f-8ca4-ca71226f7037)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
