### PR TITLE
#501 | Fix bytes input

### DIFF
--- a/src/components/ContractTab/function-interface-utils.js
+++ b/src/components/ContractTab/function-interface-utils.js
@@ -536,40 +536,6 @@ function parseBooleanArrayString(str, expectedLength) {
 }
 
 /**
- * Given a string, returns an array of byte strings iff the string is a valid representation of bytes.
- * Returns undefined if string is valid but has the wrong number of elements in the case of fixed-size arrays
- *
- * @param {string} str - string representation of an array of bytes, e.g. "[a9, ff, 02]"
- * @param {number|undefined} expectedLength
- * @returns {string[]|undefined}
- */
-function parseBytesArrayString(str, expectedLength) {
-    if (str === '[]' && expectedLength === undefined) {
-        return [];
-    }
-
-    const bytesArrayStringRegex = /^\[(([0-9A-Fa-f]{2}), *)*([0-9A-Fa-f]{2})]$/;
-
-    const stringRepresentValidBoolArray = bytesArrayStringRegex.test(str);
-    if (!stringRepresentValidBoolArray) {
-        return undefined;
-    }
-
-    const byteRegex = /[0-9A-Fa-f]{2}/g;
-    const bytesArray = str.match(byteRegex);
-
-    if (Number.isInteger(expectedLength)) {
-        const actualLength = bytesArray.length;
-
-        if (actualLength !== expectedLength) {
-            return undefined;
-        }
-    }
-
-    return bytesArray;
-}
-
-/**
  * Given a string, returns an array of string iff it is a valid JSON representation of a string array.
  * Returns undefined if string is valid but has the wrong number of elements in the case of fixed-size arrays
  *
@@ -631,7 +597,6 @@ export {
     parseAddressString,
     parseBooleanArrayString,
     parseBooleanString,
-    parseBytesArrayString,
     parseSignedIntArrayString,
     parseSignedIntString,
     parseStringArrayString,

--- a/src/i18n/de-de/index.js
+++ b/src/i18n/de-de/index.js
@@ -262,6 +262,7 @@ export default {
             incorrect_address_array_length: 'Das Array sollte { size } Adressen enthalten',
             incorrect_booleans_array_length: 'In dem Array sollten { size } Boolesche Werte enthalten sein',
             incorrect_bytes_array_length: 'Das Array sollte { size } Bytes enthalten',
+            odd_number_of_bytes: 'Es sollte eine gerade Anzahl von Bytezeichen vorhanden sein',
             incorrect_sigint_array_length: 'Das Array muss { size } signed Integers enthalten',
             incorrect_strings_array_length: 'Das Array sollte nur { size } Zeichenfolgen enthalten',
             incorrect_unsigint_array_length: 'Das Array muss { size } unsigned Integers enthalten',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -262,6 +262,7 @@ export default {
             incorrect_address_array_length: 'There should be { size } addresses in the array',
             incorrect_booleans_array_length: 'There should be { size } booleans in the array',
             incorrect_bytes_array_length: 'There should be { size } bytes in the array',
+            odd_number_of_bytes: 'There should be an even number of byte characters',
             incorrect_sigint_array_length: 'There should be { size } signed integers in the array',
             incorrect_strings_array_length: 'There should be { size } strings in the array',
             incorrect_unsigint_array_length: 'There should be { size } unsigned integers in the array',

--- a/src/i18n/es-es/index.js
+++ b/src/i18n/es-es/index.js
@@ -262,6 +262,7 @@ export default {
             incorrect_address_array_length: 'Debe haber { size } direcciones en la matriz',
             incorrect_booleans_array_length: 'Debe haber { size } booleanos en la matriz',
             incorrect_bytes_array_length: 'Debe haber { size } bytes en la matriz',
+            odd_number_of_bytes: 'Debe haber un número par de caracteres de bytes',
             incorrect_sigint_array_length: 'Debe haber { size } enteros firmados en la matriz',
             incorrect_strings_array_length: 'Debe haber { size } cadenas en la matriz',
             incorrect_unsigint_array_length: 'Debe haber { size } enteros sin firmar en la matriz',

--- a/src/i18n/fr-fr/index.js
+++ b/src/i18n/fr-fr/index.js
@@ -262,6 +262,7 @@ export default {
             incorrect_address_array_length: 'Le tableau doit contenir { size } adresses',
             incorrect_booleans_array_length: 'Le tableau doit contenir { size } booléens',
             incorrect_bytes_array_length: 'Le tableau doit contenir { size } bytes',
+            odd_number_of_bytes: 'Il devrait y avoir un nombre pair de caractères d\'octet',
             incorrect_sigint_array_length: 'Le tableau doit contenir { size } entiers signés',
             incorrect_strings_array_length: 'Le tableau doit contenir { size } chaînes de caractères',
             incorrect_unsigint_array_length: 'Le tableau doit contenir { size } entiers non signés',

--- a/src/i18n/pt-br/index.js
+++ b/src/i18n/pt-br/index.js
@@ -262,6 +262,7 @@ export default {
             incorrect_address_array_length: 'Deve haver { size } endereços na matriz',
             incorrect_booleans_array_length: 'Deve haver { size } booleanos na matriz',
             incorrect_bytes_array_length: 'Deve haver { size } bytes na matriz',
+            odd_number_of_bytes: 'Deve haver um número par de caracteres de byte',
             incorrect_sigint_array_length: 'Deve haver { size } inteiros com sinal na matriz',
             incorrect_strings_array_length: 'Deve haver { size } strings (sequência de caracteres) na matriz',
             incorrect_unsigint_array_length: 'Deve haver { size } inteiros sem sinal na matriz',

--- a/test/components/ContractTab/function-interface-utils.test.js
+++ b/test/components/ContractTab/function-interface-utils.test.js
@@ -20,7 +20,6 @@ import {
     parseAddressString,
     parseBooleanArrayString,
     parseBooleanString,
-    parseBytesArrayString,
     parseSignedIntArrayString,
     parseSignedIntString,
     parseStringArrayString,
@@ -500,30 +499,6 @@ describe('function-interface-utils', () => {
 
             expect(parseBooleanString('fals')).toBe(undefined);
             expect(parseBooleanString(3)).toBe(undefined);
-        });
-    });
-
-    describe('parseBytesArrayString', () => {
-        it('should correctly parse a string representation of bytes', () => {
-            const bytesOne = 'fa';
-            const bytesTwo = 'B4';
-
-            // any length - valid
-            expect(parseBytesArrayString('[]')).toEqual([]);
-            expect(parseBytesArrayString(`[${bytesOne}]`)).toEqual([bytesOne]);
-            expect(parseBytesArrayString(`[${bytesOne}, ${bytesTwo}]`)).toEqual([bytesOne, bytesTwo]);
-
-            // any length - invalid
-            expect(parseBytesArrayString('[1]')).toEqual(undefined);
-
-
-            // fixed length - valid
-            expect(parseBytesArrayString(`[${bytesOne}]`, 1)).toEqual([bytesOne]);
-            expect(parseBytesArrayString(`[${bytesOne}, ${bytesTwo}]`, 2)).toEqual([bytesOne, bytesTwo]);
-
-            // fixed length - invalid
-            expect(parseBytesArrayString('[]', 2)).toEqual(undefined);
-            expect(parseBytesArrayString(`[${bytesOne}]`, 2)).toEqual(undefined);
         });
     });
 


### PR DESCRIPTION
# Fixes #501

## Description
The bytes input is currently implemented incorrectly, expecting a value like `'[ab, cd, ef]'` when it should be expecting a string like `'0xabcdef'` for bytes arrays. This PR fixes that issue.

## Test scenarios
- go to https://deploy-preview-504--dev-mainnet-teloscan.netlify.app/address/0x46893403C4aD778d7FDA0CdFCe355a0A7dba3333#contract
- go to the `Write` tab
- scroll down and expand the method `estimateSendFee`
- enter the following values: 
    ```
    _dstChainId: 102    
    _toAddress: 0x0000000000000000000000000000000000000000000000000000000000000001
    _amount: 1
    _useZro: false
    _adapterParams: 0x00010000000000000000000000000000000000000000000000000000000000030d40
    ```
    - you should be able to execute the method and get a result
- in the `_toAddress` field, which is a fixed-length bytes input, enter a valid bytes string like `0xab`
    - you should see an error saying the array must be 32 bytes long
- type in a bytes string with an uneven number of byte characters, like `0xabc`
    - you should see an error saying it must be even
- type in any other invalid values
    - you should see an error
- repeat the last 3 steps in the `_adapterParams` field
    - you should see the same results, except there should be no error saying it must be 32 bytes long

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
