### PR TITLE
#507 | Add analytics (teloscan)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,23 @@
 <script lang="ts">
-import { getAntelope } from 'src/antelope';
 import { defineComponent } from 'vue';
+
+import { getAntelope, useChainStore } from 'src/antelope';
+import { TELOS_NETWORK_NAMES } from 'src/antelope/mocks/chain-constants';
 
 export const isTodayBeforeTelosCloudDown = new Date().getTime() < new Date('2023-12-31').getTime();
 
 export default defineComponent({
     name: 'App',
     mounted() {
-        const script = document.createElement('script');
-        script.src = 'https://cdn.usefathom.com/script.js';
-        script.dataset.site = 'PDKJSBKL';
-        script.dataset.spa = 'auto';
-        script.defer = true;
-        document.body.appendChild(script);
+        const network = useChainStore().currentChain.settings.getNetwork();
+        if (TELOS_NETWORK_NAMES.includes(network)) {
+            const script = document.createElement('script');
+            script.src = 'https://cdn.usefathom.com/script.js';
+            script.dataset.site = 'PDKJSBKL';
+            script.dataset.spa = 'auto';
+            script.defer = true;
+            document.body.appendChild(script);
+        }
 
         if (isTodayBeforeTelosCloudDown) {
             getAntelope().config.notifyRememberInfoHandler(

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,13 @@ export const isTodayBeforeTelosCloudDown = new Date().getTime() < new Date('2023
 export default defineComponent({
     name: 'App',
     mounted() {
+        const script = document.createElement('script');
+        script.src = 'https://cdn.usefathom.com/script.js';
+        script.dataset.site = 'PDKJSBKL';
+        script.dataset.spa = 'auto';
+        script.defer = true;
+        document.body.appendChild(script);
+
         if (isTodayBeforeTelosCloudDown) {
             getAntelope().config.notifyRememberInfoHandler(
                 this.$t('temporal.telos_cloud_discontinued_title'),

--- a/src/antelope/mocks/AccountStore.ts
+++ b/src/antelope/mocks/AccountStore.ts
@@ -51,9 +51,9 @@ class AccountStore {
         } as AccountModel;
     }
 
-    async loginEVM({ authenticator, network }: LoginEVMActionData): Promise<boolean> {
+    async loginEVM({ authenticator, network }: LoginEVMActionData, trackAnalyticsEvents: boolean): Promise<boolean> {
         currentAuthenticator = authenticator;
-        currentAccount = await authenticator.login(network);
+        currentAccount = await authenticator.login(network, trackAnalyticsEvents);
         const account = useAccountStore().getAccount(authenticator.label);
         getAntelope().events.onLoggedIn.next(account);
         return true;

--- a/src/antelope/mocks/ChainStore.ts
+++ b/src/antelope/mocks/ChainStore.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 // Mocking ChainStore -----------------------------------
+declare const fathom: { trackGoal: (eventId: string, value: 0) => void };
 
 import { RpcEndpoint } from 'universal-authenticator-library';
 import { NativeCurrencyAddress, TokenClass } from 'src/antelope/types';
@@ -23,7 +24,15 @@ export interface EVMChainSettings {
 const settings = {
     getChainId: () => process.env.NETWORK_EVM_CHAIN_ID,
     getDisplay: () => process.env.NETWORK_EVM_DISPLAY,
-    trackAnalyticsEvent: () => void 0,
+    trackAnalyticsEvent(params: Record<string, unknown>): void {
+        if (typeof fathom === 'undefined') {
+            console.warn(`Failed to track event with ID ${params.id}: Fathom Analytics not loaded`);
+            return;
+        }
+
+        const id = params.id as string;
+        fathom.trackGoal(id, 0);
+    },
     getRPCEndpoint: () => {
         // extract the url parts
         const regex = /^(https?):\/\/([^:/]+)(?::(\d+))?(\/.*)?$/;

--- a/src/antelope/mocks/EVMStore.ts
+++ b/src/antelope/mocks/EVMStore.ts
@@ -88,7 +88,7 @@ class EVMStore {
                         if (!authenticator) {
                             console.error('Inconsistency: logged account authenticator is null', authenticator);
                         } else {
-                            useAccountStore().loginEVM({ authenticator,  network });
+                            useAccountStore().loginEVM({ authenticator,  network }, false);
                         }
                     }
                 } else {

--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -59,8 +59,10 @@ export abstract class EVMAuthenticator {
         return (useChainStore().getChain(this.label).settings as EVMChainSettings);
     }
 
-    async login(network: string): Promise<addressString | null> {
+    async login(network: string, trackAnalyticsEvents?: boolean): Promise<addressString | null> {
         this.trace('login', network);
+        this.trace('Login analytics enabled =', trackAnalyticsEvents);
+
         const chain = useChainStore();
         try {
             chain.setChain(CURRENT_CONTEXT, network);

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -220,7 +220,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
                     }
 
                     if (wagmiConnected()) {
-                        resolve(this.walletConnectLogin(network));
+                        resolve(this.walletConnectLogin(network, true));
                     }
                 });
                 this.web3Modal.openModal();

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -81,7 +81,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
         return new WalletConnectAuth(this.options, this.wagmiClient, label);
     }
 
-    async walletConnectLogin(network: string): Promise<addressString | null> {
+    async walletConnectLogin(network: string, trackAnalyticsEvents: boolean): Promise<addressString | null> {
         this.trace('walletConnectLogin');
         const chainSettings = this.getChainSettings();
         const isOnTelos = TELOS_NETWORK_NAMES.includes(chainSettings.getNetwork());
@@ -114,7 +114,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
                 console.error(e);
             }
 
-            if (isOnTelos) {
+            if (isOnTelos && trackAnalyticsEvents) {
                 this.trace(
                     'login',
                     'trackAnalyticsEvent -> login successful',
@@ -138,7 +138,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
         } catch (e) {
             // This is a non-expected error
             console.error(e);
-            if (isOnTelos) {
+            if (isOnTelos && trackAnalyticsEvents) {
                 this.trace(
                     'walletConnectLogin',
                     'trackAnalyticsEvent -> login failed',
@@ -176,7 +176,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
                     { id: TELOS_ANALYTICS_EVENT_IDS.loginStarted },
                 );
             }
-            return this.walletConnectLogin(network);
+            return this.walletConnectLogin(network, trackAnalyticsEvents);
         } else {
             return new Promise((resolve) => {
                 this.trace('login', 'web3Modal.openModal()');

--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -165,7 +165,7 @@ export default defineComponent({
             }
             const authenticator = auth.newInstance(label);
             const network = useChainStore().currentChain.settings.getNetwork();
-            useAccountStore().loginEVM({ authenticator, network }).then(() => {
+            useAccountStore().loginEVM({ authenticator, network }, true).then(() => {
                 const address = useAccountStore().getAccount(label).account;
                 this.setLogin({ address });
                 localStorage.setItem(LOGIN_DATA_KEY, JSON.stringify({


### PR DESCRIPTION
# Fixes #507 

## Description
This PR enables analytics for teloscan when logging in

For reference, here are the event IDs used: 
```
export const TELOS_ANALYTICS_EVENT_IDS = {
    loginStarted: 'GXQ8FOAU',
    loginSuccessful: 'B1BZBK5R',
    loginSuccessfulMetamask: 'JQTSKEFY',
    loginFailedMetamask: 'PKHBRTYV',
    loginSuccessfulSafepal: 'WV5OSVMQ',
    loginFailedSafepal: '7WSBR8LA',
    loginSuccessfulOreId: 'HUDIQQEK',
    loginFailedOreId: 'AJXWOXWJ',
    loginFailedWalletConnect: 'ZVKXJDK1',
    loginSuccessfulWalletConnect: 'AQMOMICF',
};
```

## Test scenarios
- this PR will need to be tested locally. run `git fetch --all && git checkout 507-login-analytics && yarn && yarn dev`
- open `ChainStore.ts` and paste this at the top of the function: `console.log('tracking fathom event with ID ' + params.id);`
- open your browser to http://localhost:8080
- open your browser dev console
- in the dev console, filter messages by `fathom` (so you can see fathom logging easier)
- if you are using brave browser or any ad blocker, disable it
- if you have already connected your Metamask to localhost, disconnect it from the metamask menu
- click "Connect wallet" in Teloscan
- click Metamask
    - you should see an event fire with the `loginStarted` event ID
- connect with metamask
    - you should see events fire with `loginSuccessful` and `loginSuccessfulMetamask` IDs
- log out
- click "Connect Wallet"
- click Wallet Connect
    - you should see an event fire with the `loginStarted` event ID
- proceed to log in with walletconnect using your phone
    - you should see events fire with `loginSuccessful` and `loginSuccessfulWalletConnect` IDs

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
