### PR TITLE
prompt switch network only before transaction signing

### DIFF
--- a/src/antelope/mocks/AccountStore.ts
+++ b/src/antelope/mocks/AccountStore.ts
@@ -3,13 +3,16 @@
 // Mocking AccountStore -----------------------------------
 // useAccountStore().getAccount(this.label).account as addressString;
 import { EVMAuthenticator } from 'src/antelope/wallets';
-import { addressString } from 'src/antelope/types';
+import { AntelopeError, addressString } from 'src/antelope/types';
 import { CURRENT_CONTEXT, EVMChainSettings, createTraceFunction, useChainStore } from 'src/antelope/mocks';
 import { BigNumber } from 'ethers'; 'src/antelope/mocks/FeedbackStore';
 import { getAntelope } from 'src/antelope/mocks/AntelopeConfig';
 import { useFeedbackStore } from 'src/antelope/mocks';
 import { EvmABI, EvmFunctionParam, Label, TransactionResponse } from 'src/antelope/types';
 import { subscribeForTransactionReceipt } from 'src/antelope/wallets/utils/trx-utils';
+
+export const errorToString = (error: unknown) =>
+    getAntelope().config.errorToStringHandler(error);
 
 export interface AccountModel {
     label: typeof CURRENT_CONTEXT;
@@ -98,6 +101,10 @@ class AccountStore {
         const funcname = 'signCustomTransaction';
         this.trace(funcname, label, contract, abi, parameters, value?.toString());
 
+        if (! await this.assertNetworkConnection(label)) {
+            throw new AntelopeError('antelope.evm.error_switch_chain_rejected');
+        }
+
         try {
             useFeedbackStore().setLoading(funcname);
             const account = this.loggedAccount as EvmAccountModel;
@@ -127,6 +134,59 @@ class AccountStore {
             throw trxError;
         } finally {
             useFeedbackStore().unsetLoading(funcname);
+        }
+    }
+
+    async isConnectedToCorrectNetwork(label: string): Promise<boolean> {
+        this.trace('isConnectedToCorrectNetwork', label);
+        try {
+            useFeedbackStore().setLoading('account.isConnectedToCorrectNetwork');
+            const authenticator = useAccountStore().getAccount(label)?.authenticator as EVMAuthenticator;
+            return authenticator.isConnectedToCorrectChain();
+        } catch (error) {
+            console.error('Error: ', errorToString(error));
+            return Promise.resolve(false);
+        } finally {
+            useFeedbackStore().unsetLoading('account.isConnectedToCorrectNetwork');
+        }
+    }
+
+    async assertNetworkConnection(label: string): Promise<boolean> {
+        if (!await useAccountStore().isConnectedToCorrectNetwork(label)) {
+            return new Promise<boolean>((resolve) => {
+                const ant = getAntelope();
+                const authenticator = useAccountStore().loggedAccount.authenticator as EVMAuthenticator;
+                const networkName = useChainStore().loggedChain.settings.getDisplay();
+                const errorMessage = ant.config.localizationHandler('evm_wallet.incorrect_network', { networkName });
+                let userClickedSwitch = false;
+                ant.config.notifyFailureWithAction(errorMessage, {
+                    label: ant.config.localizationHandler('evm_wallet.switch'),
+                    handler: async () => {
+                        userClickedSwitch = true;
+                        try {
+                            await authenticator.ensureCorrectChain();
+                            if (!await useAccountStore().isConnectedToCorrectNetwork(label)) {
+                                resolve(false);
+                            } else {
+                                resolve(true);
+                            }
+                        } catch (error) {
+                            const message = (error as Error).message;
+                            if (message === 'antelope.evm.error_switch_chain_rejected') {
+                                ant.config.notifyNeutralMessageHandler(message);
+                            }
+                            resolve(false);
+                        }
+                    },
+                    onDismiss: () => {
+                        if (!userClickedSwitch) {
+                            resolve(false);
+                        }
+                    },
+                });
+            });
+        } else {
+            return true;
         }
     }
 

--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -92,6 +92,24 @@ export abstract class EVMAuthenticator {
         }
     }
 
+    async autoLogin(network: string, account: string, trackAnalyticsEvents?: boolean): Promise<addressString> {
+        this.trace('autoLogin', network, account);
+        this.trace('AutoLogin analytics enabled =', trackAnalyticsEvents);
+
+        const chain = useChainStore();
+        try {
+            chain.setChain(CURRENT_CONTEXT, network);
+            return account as addressString;
+        } catch (error) {
+            if ((error as unknown as ExceptionError).code === 4001) {
+                throw new AntelopeError('antelope.evm.error_connect_rejected');
+            } else {
+                console.error('Error:', error);
+                throw new AntelopeError('antelope.evm.error_login');
+            }
+        }
+    }
+
     async ensureCorrectChain(): Promise<ethers.providers.Web3Provider> {
         this.trace('ensureCorrectChain');
         if (usePlatformStore().isMobile) {

--- a/src/assets/icon--warning.svg
+++ b/src/assets/icon--warning.svg
@@ -1,0 +1,3 @@
+<svg width="23" height="19" viewBox="0 0 23 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.0347 0L0.034668 19H22.0347M11.0347 4L18.5647 17H3.50467M10.0347 8V12H12.0347V8M10.0347 14V16H12.0347V14" fill="#282828"/>
+</svg>

--- a/src/boot/errorHandling.js
+++ b/src/boot/errorHandling.js
@@ -59,6 +59,7 @@ class NotificationAction {
         this.label     = payload.label;
         this.class     = payload.class;
         this.handler   = payload.handler;
+        this.onDismiss = payload.onDismiss;
         this.iconRight = payload.iconRight;
         this.color     = payload.color;
     }
@@ -68,6 +69,7 @@ const crossIcon = require('src/assets/icon--cross.svg');
 const infoIcon  = require('src/assets/icon--info.svg');
 const checkIcon = require('src/assets/icon--check.svg');
 const discoIcon = require('src/assets/icon--disconnected.svg');
+const warningIcon = require('src/assets/icon--warning.svg');
 
 const html = `
     <div class="c-notify__container c-notify__container--{type} c-notify__container--{random}">
@@ -142,11 +144,14 @@ const notifyMessage = function(type, icon, title, message, payload, remember = '
         class: 'c-notify__action-btn c-notify__action-btn--hide',
     };
 
+    let onDismiss = null;
+
     // adding buttons
     if (typeof payload === 'string' && type === 'success') {
         actions.push(link_btn);
     } else if (typeof payload === 'object' && payload instanceof NotificationAction) {
         actions.push(action_btn);
+        onDismiss = payload.onDismiss;
     } else if (typeof payload === 'object' && type === 'error') {
         actions.push(details_btn);
     } else {
@@ -206,6 +211,7 @@ const notifyMessage = function(type, icon, title, message, payload, remember = '
         html: true,
         classes: 'c-notify',
         actions,
+        onDismiss,
     });
 };
 
@@ -253,6 +259,16 @@ const notifyFailureWithAction = function(message, payload) {
         'error',
         crossIcon,
         this.$t('notification.error_title').toUpperCase(),
+        message,
+        new NotificationAction(payload),
+    );
+};
+
+const notifyWarningWithAction = function(message, payload) {
+    return notifyMessage.bind(this)(
+        'error',
+        warningIcon,
+        this.$t('notification.warning_title').toUpperCase(),
         message,
         new NotificationAction(payload),
     );
@@ -332,6 +348,7 @@ export default boot(({ app, store }) => {
     app.config.globalProperties.$notifySuccessCopy        = notifySuccessCopy.bind(store);
     app.config.globalProperties.$notifyFailure            = notifyFailure.bind(store);
     app.config.globalProperties.$notifyFailureWithAction  = notifyFailureWithAction.bind(store);
+    app.config.globalProperties.$notifyWarningWithAction  = notifyWarningWithAction.bind(store);
     app.config.globalProperties.$notifyDisconnected       = notifyDisconnected.bind(store);
     app.config.globalProperties.$notifyNeutralMessage     = notifyNeutralMessage.bind(store);
     app.config.globalProperties.$notifyRememberInfo       = notifyRememberInfo.bind(store);
@@ -340,6 +357,7 @@ export default boot(({ app, store }) => {
     store['$notifySuccessCopy']                           = app.config.globalProperties.$notifySuccessCopy;
     store['$notifyFailure']                               = app.config.globalProperties.$notifyFailure;
     store['$notifyFailureWithAction']                     = app.config.globalProperties.$notifyFailureWithAction;
+    store['$notifyWarningWithAction']                     = app.config.globalProperties.$notifyWarningWithAction;
     store['$notifyDisconnected']                          = app.config.globalProperties.$notifyDisconnected;
     store['$notifyNeutralMessage']                        = app.config.globalProperties.$notifyNeutralMessage;
     store['$notifyRememberInfo']                          = app.config.globalProperties.$notifyRememberInfo;

--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -70,6 +70,7 @@ export default defineComponent({
             localStorage.setItem(LOGIN_DATA_KEY, JSON.stringify({
                 type: LOGIN_EVM,
                 provider: pr_name,
+                account: address,
             }));
         });
 
@@ -80,7 +81,7 @@ export default defineComponent({
 
         const loginObj = JSON.parse(loginData);
         if (loginObj.type === LOGIN_EVM) {
-            this.loginWithAntelope(loginObj.provider);
+            this.loginWithAntelope(loginObj.provider, loginObj.account);
         } else if (loginObj.type === LOGIN_NATIVE) {
             const wallet = this.authenticators.find((a: { getName: () => any; }) => a.getName() === loginObj.provider);
             if (wallet) {
@@ -144,7 +145,7 @@ export default defineComponent({
                     nativeAccount: accountName,
                 });
                 this.$providerManager.setProvider(account);
-                localStorage.setItem(LOGIN_DATA_KEY, JSON.stringify({ type: LOGIN_NATIVE, provider: wallet.getName() }));
+                localStorage.setItem(LOGIN_DATA_KEY, JSON.stringify({ type: LOGIN_NATIVE, provider: wallet.getName(), account: evmAccount.address }));
             }
             this.$emit('hide');
         },
@@ -156,7 +157,7 @@ export default defineComponent({
 
             return wallet.getStyle().icon;
         },
-        async loginWithAntelope(name:string) {
+        async loginWithAntelope(name:string, autoLogAccount?: string) {
             const label = CURRENT_CONTEXT;
             const auth = getAntelope().wallets.getAuthenticator(name);
             if (!auth) {
@@ -165,12 +166,13 @@ export default defineComponent({
             }
             const authenticator = auth.newInstance(label);
             const network = useChainStore().currentChain.settings.getNetwork();
-            useAccountStore().loginEVM({ authenticator, network }, true).then(() => {
+            useAccountStore().loginEVM({ authenticator, network, autoLogAccount }, true).then(() => {
                 const address = useAccountStore().getAccount(label).account;
                 this.setLogin({ address });
                 localStorage.setItem(LOGIN_DATA_KEY, JSON.stringify({
                     type: LOGIN_EVM,
                     provider: name,
+                    account: address,
                 }));
             });
             this.$emit('hide');


### PR DESCRIPTION
# Fixes #515

## Description

This PR includes a new function `assertNetworkConnection` for the account store that will prompt the user to change the network and block the code until the user either refuses or accepts and effectively changes the network. 

It also removes the code responsible for warning the user that a network switch has been detected because we don't need it if we are only displaying data. However, when the user tries to sign a transaction we need to explicitly check the network and prompt the user to change it.

## Test scenarios
- Login using Metamask
- Once logged, open Metamask, change the network and come back to the web app
  - you should not get any notification
  - you should be able to explore all sections and your data should be correct
- got to any transaction page and try to perform one: e.g. liquid staking (STLOS)
  - you should be prompted to change the network
  - if you refuse to switch the network, the transaction cancels quietly
  - if you cancel the switch you get a neutral notification
  - if you accept and continue until effectively change the network, the transaction should go on without the need for you to hit the action button again.

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Screnn captures

[teloscan--switch-chains.webm](https://github.com/telosnetwork/teloscan/assets/4420760/f9592bb9-f4ed-4d3a-b166-00d20c8e90e2)


## Checklist:
<!---
You can remove the items that are not relevant for your project.

-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
