### PR TITLE
#532 | Homepage latest blocks

### DIFF
--- a/src/components/BlockOverview.vue
+++ b/src/components/BlockOverview.vue
@@ -156,13 +156,20 @@ watch(() => props.data, (newData) => {
         </div>
         <div class="c-block-data__col-val">
             <div class="c-block-data__row-value">
-                <span class="c-block-data__row-value-link" @click="trxTableClick">
-                    {{
-                        transactionsCount === 1
-                            ? $t('components.blocks.count_transaction')
-                            : $t('components.blocks.count_transactions', { count: transactionsCount })
-                    }}
-                </span>
+                <template
+                    v-if="transactionsCount > 0"
+                >
+                    <span class="c-block-data__row-value-link" @click="trxTableClick">
+                        {{
+                            transactionsCount === 1
+                                ? $t('components.blocks.count_transaction')
+                                : $t('components.blocks.count_transactions', { count: transactionsCount })
+                        }}
+                    </span>
+                </template>
+                <template v-else>
+                    {{ $t('components.blocks.count_transactions', { count: transactionsCount }) }}
+                </template>
                 {{ $t('components.blocks.in_this_block') }}
             </div>
         </div>

--- a/src/components/BlockTable.vue
+++ b/src/components/BlockTable.vue
@@ -121,6 +121,11 @@ async function onPaginationChange(settings: { pagination: Pagination}) {
 async function fetchBlocksPage() {
     const path = getPath();
     const result = await indexerApi.get(path);
+    result.data.results = result.data.results.map((block: BlockData) => {
+        block.blockHeight = +(block.number ?? 0);
+        block.transactionsCount = +(block.transactionCount ?? 0);
+        return block;
+    });
     return result;
 }
 
@@ -189,11 +194,6 @@ function getGasUsed(gasUsed: string) {
     return '0';
 }
 
-
-function getTransactionsCount(transactionsCount: number | undefined) {
-    return transactionsCount?.toLocaleString() ?? '0';
-}
-
 </script>
 
 <template>
@@ -240,9 +240,9 @@ function getTransactionsCount(transactionsCount: number | undefined) {
         </q-tr>
     </template>
     <template v-slot:body="props">
-        <q-tr :key="props.row.number" :props="props">
+        <q-tr :key="props.row.blockHeight" :props="props">
             <q-td key="block" :props="props">
-                <BlockField :block="props.row.number"/>
+                <BlockField :block="props.row.blockHeight"/>
             </q-td>
             <q-td key="timestamp" :props="props">
                 <DateField :epoch="props.row.timestamp / 1000" :force-show-age="showDateAge"/>
@@ -253,10 +253,10 @@ function getTransactionsCount(transactionsCount: number | undefined) {
             <q-td key='transactionsCount' :props="props">
                 <span class="c-block-table__cell-trx">
                     {{
-                        getTransactionsCount(props.row.transactionCount) === '1'
+                        props.row.transactionsCount === 1
                             ? $t('components.blocks.count_transaction')
                             : $t('components.blocks.count_transactions', {
-                                count: getTransactionsCount(props.row.transactionCount)
+                                count: props.row.transactionsCount
                             })
                     }}
                 </span>

--- a/src/pages/home/HomeLatestBlocks.vue
+++ b/src/pages/home/HomeLatestBlocks.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import HomeLatestDataTableRow from 'src/pages/home/HomeLatestDataTableRow.vue';
+import TransactionFeeField from 'components/TransactionFeeField.vue';
+import BlockField from 'components/BlockField.vue';
+import DateField from 'components/DateField.vue';
+import { indexerApi } from 'src/boot/telosApi';
+import { onMounted, ref } from 'vue';
+import { BlockData } from 'src/types';
+import { useQuasar } from 'quasar';
+import { useI18n } from 'vue-i18n';
+// import { ethers } from 'ethers'; // FIXME: remove
+
+const $q = useQuasar();
+const { t: $t } = useI18n();
+// const locale = useI18n().locale.value; // FIXME: remove
+const loading = ref(true);
+// const blocks = ref<BlockData[]>([] as unknown as BlockData[]); // FIXME: remove
+const blocks = ref<BlockData[]>([1, 2, 3, 4, 5, 6] as unknown as BlockData[]);
+
+async function fetchBlocksPage() {
+    console.log('fetchBlocksPage()', loading.value); // FIXME: remove
+    const path = getPath();
+    const result = await indexerApi.get(path);
+
+    result.data.results = result.data.results.map((block: BlockData) => {
+        block.blockHeight = +(block.number ?? 0);
+        block.transactionsCount = +(block.transactionCount ?? 0);
+        return block;
+    });
+    return result;
+}
+
+async function parseBlocks() {
+    console.log('parseBlocks()', loading.value); // FIXME: remove
+    loading.value = true;
+
+    try {
+        let response = await fetchBlocksPage();
+        blocks.value = response.data.results;
+        loading.value = false;
+        console.log('blocks.value', blocks.value); // FIXME: remove
+        console.log('loading.value', loading.value); // FIXME: remove
+    } catch (e: unknown) {
+        $q.notify({
+            type: 'negative',
+            message: $t('components.blocks.transaction.load_error'),
+            caption: (e as {message:string}).message,
+        });
+        loading.value = false;
+    }
+}
+
+
+function getPath() {
+    let path = 'blocks?limit=6&includeCount=1';
+    return path;
+}
+
+onMounted(() => {
+    // eslint-disable-next-line no-constant-condition
+    //if (1 > 0) { // FIXME: remove
+    parseBlocks();
+    //}
+});
+
+// FIXME: remove
+// const gasUsedFor = (block: BlockData) => {
+//     if (block) {
+//         const gas = ethers.BigNumber.from(block.gasUsed);
+//         try {
+//             return gas.toNumber().toLocaleString(locale);
+//         } catch (e) {
+//             console.error(e);
+//             return gas.toString();
+//         }
+//     }
+//     return '0';
+// };
+
+const gasPrice = '0x754d490126';
+
+</script>
+
+<template>
+<table class="c-latest-blocks">
+    <HomeLatestDataTableRow v-for="block in blocks" :key="block.blockHeight" :loading="loading">
+        <template v-slot:icon>
+            <q-icon name="view_in_ar" size="24px" />
+        </template>
+        <template v-slot:column-one>
+            <BlockField :block="block.blockHeight"/>
+            <br>
+            <DateField :epoch="block.timestamp / 1000" :force-show-age="true"/>
+        </template>
+        <template v-slot:column-two>
+
+            <template v-if="block.transactionsCount > 0">
+                <a :href="`/block/${block.blockHeight}?tab=transactions`">
+                    {{
+                        block.transactionsCount === 1
+                            ? $t('components.blocks.count_transaction')
+                            : $t('components.blocks.count_transactions', {
+                                count: block.transactionsCount
+                            })
+                    }}
+                </a>
+            </template>
+            <template v-else>
+                {{
+                    $t('components.blocks.count_transactions', { count: block.transactionsCount })
+                }}
+            </template>
+
+            <br>
+
+            {{ $t('components.blocks.in_this_block') }}
+
+        </template>
+        <template v-slot:column-three>
+            <div>
+                <TransactionFeeField
+                    :showTotalGasFee="true"
+                    :gasUsed="block.gasUsed"
+                    :gasPrice="gasPrice"
+                />
+                TLOS
+            </div>
+        </template>
+    </HomeLatestDataTableRow>
+</table>
+</template>
+
+<style lang="scss">
+.c-latest-blocks {
+    width: 100%;
+    border-collapse: collapse;
+    max-height: 100px;
+}
+</style>

--- a/src/pages/home/HomeLatestBlocks.vue
+++ b/src/pages/home/HomeLatestBlocks.vue
@@ -126,12 +126,7 @@ onMounted(() => {
     max-height: 100px;
 
     &__gas-used {
-        border: 1px solid var(--border-color);
-        border-radius: 8px;
-        padding: 4px 8px;
-        font-size: 0.65rem;
-        font-weight: bold;
-        width: max-content;
+        @include token-value;
     }
 }
 </style>

--- a/src/pages/home/HomeLatestBlocks.vue
+++ b/src/pages/home/HomeLatestBlocks.vue
@@ -10,11 +10,14 @@ import { useI18n } from 'vue-i18n';
 import { ethers } from 'ethers';
 import { WEI_PRECISION, formatWei } from 'src/lib/utils';
 
+// variables
 const $q = useQuasar();
 const { t: $t } = useI18n();
 const loading = ref(true);
 const blocks = ref<BlockData[]>([1, 2, 3, 4, 5, 6] as unknown as BlockData[]);
+const gasPrice = '0x754d490126';
 
+// functions
 async function fetchBlocksPage() {
     const path = getPath();
     const result = await indexerApi.get(path);
@@ -50,10 +53,6 @@ function getPath() {
     return path;
 }
 
-onMounted(() => {
-    parseBlocks();
-});
-
 const gasUsedFor = (block: BlockData) => {
     if (block) {
         try {
@@ -66,7 +65,10 @@ const gasUsedFor = (block: BlockData) => {
     return '0.0000 TLOS';
 };
 
-const gasPrice = '0x754d490126';
+// lifecycle
+onMounted(() => {
+    parseBlocks();
+});
 
 </script>
 

--- a/src/pages/home/HomeLatestDataContainer.vue
+++ b/src/pages/home/HomeLatestDataContainer.vue
@@ -68,7 +68,7 @@ const showCustomize = computed(() => Object.keys(props.options).length > 1);
 
     <q-separator />
 
-    <q-card-section>
+    <q-card-section class="c-latest-data__content">
         <template v-for="(name, key) in props.options" :key="key">
             <slot v-if="selectedOption === key" :name="key"></slot>
         </template>
@@ -87,12 +87,20 @@ const showCustomize = computed(() => Object.keys(props.options).length > 1);
 <style lang="scss">
 .c-latest-data {
     border-radius: 12px;
+    height: 550px;
+    position: relative;
+    padding-bottom: 24px;
 
     &__header {
         &-title {
             font-weight: 600;
             font-size: 0.8rem;
         }
+    }
+
+    &__content {
+        overflow-y: auto;
+        max-height: 485px;
     }
 
     &__menu-opt-check {
@@ -103,6 +111,10 @@ const showCustomize = computed(() => Object.keys(props.options).length > 1);
     }
 
     &__footer {
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        left: 0;
         cursor: pointer;
         display: flex;
         gap: 5px;
@@ -115,22 +127,4 @@ const showCustomize = computed(() => Object.keys(props.options).length > 1);
         }
     }
 }
-
-
-/*
-.c-latest-data {
-    &__header {
-        display: flex;
-        justify-content: space-between;
-    }
-}
-*/
-/*
-.header button {
-  margin-right: 10px;
-}
-.header button.active {
-  font-weight: bold;
-}
-*/
 </style>

--- a/src/pages/home/HomeLatestDataTableRow.vue
+++ b/src/pages/home/HomeLatestDataTableRow.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+defineProps<{
+    loading: boolean;
+}>();
+</script>
+
+<template>
+<div
+    :class="{
+        'c-latest-data-row': true,
+        'c-latest-data-row--loading': loading
+    }"
+>
+    <template v-if="loading">
+        <div>
+            <q-skeleton type="rect" size="48px" />
+        </div>
+        <div>
+            <q-skeleton type="rect" height="22px" class="q-mb-xs" />
+            <q-skeleton type="rect" height="22px" />
+        </div>
+        <div>
+            <q-skeleton type="rect" height="22px" class="q-mb-xs" />
+            <q-skeleton type="rect" height="22px" />
+        </div>
+        <div>
+            <q-skeleton type="rect" height="22px" class="q-mb-xs" />
+            <q-skeleton type="rect" height="22px" />
+        </div>
+    </template>
+    <template v-else>
+        <div class="c-latest-data-row__column-one">
+            <slot name="icon">
+            </slot>
+        </div>
+        <div class="c-latest-data-row__column-two">
+            <slot name="column-one">
+            </slot>
+        </div>
+        <div class="c-latest-data-row__column-three">
+            <slot name="column-two">
+            </slot>
+        </div>
+        <div class="c-latest-data-row__column-four">
+            <slot name="column-three">
+            </slot>
+        </div>
+    </template>
+</div>
+
+</template>
+
+<style lang="scss">
+.c-latest-data-row {
+    $this: &;
+
+    border-bottom: 1px solid var(--border-color);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px 0;
+
+    @media screen and (min-width: $breakpoint-lg-min) {
+        flex-direction: row;
+        align-items: center;
+    }
+
+    &__column-one {
+        display: none;
+        justify-content: center;
+        align-items: center;
+        height: 48px;
+        width: 48px;
+        background-color: $grey-3;
+        border-radius: 12px;
+
+        body.body--dark & {
+            background-color: $grey-9;
+        }
+
+        @media screen and (min-width: $breakpoint-lg-min) {
+            display: flex;
+        }
+    }
+
+    &__column-two {
+        @media screen and (min-width: $breakpoint-lg-min) {
+            width: 38%;
+        }
+    }
+
+    &__column-three {
+        @media screen and (min-width: $breakpoint-lg-min) {
+            width: 38%;
+            flex-grow: 1;
+        }
+    }
+
+    &__column-four {
+        @media screen and (min-width: $breakpoint-lg-min) {
+            width: 20%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+    }
+}
+</style>

--- a/src/pages/home/HomePage.vue
+++ b/src/pages/home/HomePage.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+import type { LatestContainerOptions } from 'src/types';
+
 import HomeInfo from 'src/pages/home/HomeInfo.vue';
-import LatestDataContainer from 'src/components/LatestDataContainer.vue';
+import HomeLatestDataContainer from 'src/pages/home/HomeLatestDataContainer.vue';
+import HomeLatestDataTableRow from 'src/pages/home/HomeLatestDataTableRow.vue';
+import HomeLatestBlocks from 'src/pages/home/HomeLatestBlocks.vue';
 import AppSearch from 'src/components/AppSearch.vue';
-import { ref } from 'vue';
-import { LatestContainerOptions } from 'src/types';
+
 
 const { t: $t } = useI18n();
 
@@ -43,27 +47,42 @@ const right_options = ref<LatestContainerOptions>({
             <AppSearch :homepage-mode="true" />
         </div>
     </div>
-    <div class="row q-mt-xl">
+    <div class="row q-my-xl">
         <div class="col-12">
             <HomeInfo />
         </div>
     </div>
-    <div class="c-home__data">
-        <div class="c-home__data-col">
-            <LatestDataContainer :options="left_options">
+    <div class="row q-col-gutter-md">
+        <div class="col-12 col-md-6">
+            <HomeLatestDataContainer :options="left_options">
                 <template v-slot:blocks>
-                    <div>Showing Latest Blocks</div>
-                    <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor odio in pretium bibendum. Fusce ac felis et ipsum aliquet bibendum.</div>
+                    <HomeLatestBlocks />
                 </template>
-            </LatestDataContainer>
+            </HomeLatestDataContainer>
         </div>
-        <div class="c-home__data-col">
-            <LatestDataContainer :options="right_options">
+        <div class="col-12 col-md-6">
+            <HomeLatestDataContainer :options="right_options">
                 <template v-slot:transactions>
-                    <div>Showing Latest Transactions</div>
-                    <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec auctor odio in pretium bibendum. Fusce ac felis et ipsum aliquet bibendum.</div>
+                    <HomeLatestDataTableRow v-for="index in [1, 2, 3, 4, 5, 6]" :key="index" :loading="false">
+                        <template v-slot:icon>
+                            <q-icon size="20px" name="far fa-file-alt" />
+                        </template>
+                        <template v-slot:column-one>
+                            <span>Some text</span>
+                            <br>
+                            <span>Some more text</span>
+                        </template>
+                        <template v-slot:column-two>
+                            <span>Some text</span>
+                            <br>
+                            <span>Some more text</span>
+                        </template>
+                        <template v-slot:column-three>
+                            <span>text</span>
+                        </template>
+                    </HomeLatestDataTableRow>
                 </template>
-            </LatestDataContainer>
+            </HomeLatestDataContainer>
         </div>
     </div>
 </q-page>

--- a/src/types/BlockData.ts
+++ b/src/types/BlockData.ts
@@ -1,7 +1,8 @@
 export interface BlockData {
-    transactionsCount: number;
-    number: string;
-    blockHeight: string; // same as number
+    number: string;             // this is returning from indexer but it should be called blockHeight
+    blockHeight: number;        // replicates the number value in number format (not string)
+    transactionCount: string;   // this is returning from indexer but it should be called transactionsCount: https://api.testnet.teloscan.io/v1/blocks?includeCount=1
+    transactionsCount: number;  // replicates the transactionCount value in number format (not string)
     logsBloom: string;
     gasLimit: string;
     gasUsed: string;


### PR DESCRIPTION
# Fixes #532

## Description

This PR adds the HomeLatestBlocks component holding the last produced blocks.

## Test scenarios
- go to [this link](https://deploy-preview-575--teloscan-redesign.netlify.app/)
- wait until you see the component loaded
  - you should see the last 6 blocks displaying:
     - number (blockHeight)
     - number of transactions
     - gas used

## Screenshots

![image](https://github.com/telosnetwork/teloscan/assets/4420760/e6b4d0a1-5c0b-4dc7-8a73-39309cf63952)

![image](https://github.com/telosnetwork/teloscan/assets/4420760/a91ba88d-810f-474f-9591-81e946dab5d2)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage
-   [x] I have updated relevant documentation and/or opened a separate issue to cover the updates (Issue URL: )
