### PR TITLE
#579 | bugfix - Notification text not visible on dark mode

### DIFF
--- a/src/css/components/_notification.scss
+++ b/src/css/components/_notification.scss
@@ -84,7 +84,7 @@ $notify-info: #008888;
       margin-right: 0.5rem;
     }
     label {
-      color: var(--text-color, #000);
+      color: black;
       @include text--paragraph;
     }
   }
@@ -114,7 +114,7 @@ $notify-info: #008888;
     }
   }
   &__message {
-    color: var(--text-color, #000);
+    color: black;
     padding: var(--c-notify__message--padding);
     text-align: var(--c-notify__message--align, center);
     span {
@@ -126,7 +126,7 @@ $notify-info: #008888;
     }
   }
   &__action-btn {
-    color: var(--text-color, #000);
+    color: black;
     &--hide {
       color: transparent;
       background-color: transparent;


### PR DESCRIPTION
# Fixes #579 

Link: https://deploy-preview-580--teloscan-stage.netlify.app/

## Description

This PR forces black to be the text color on notifications.

## Test scenarios
- Try to reproduce the bug described in #579

