### PR TITLE
More things fixed

### DIFF
--- a/src/components/BlockOverview.vue
+++ b/src/components/BlockOverview.vue
@@ -78,7 +78,7 @@ const nextBlock = () => {
 
 watch(() => props.data, (newData) => {
     blockData.value = newData ?? null;
-    const newNumber = Number(newData?.number);
+    const newNumber = Number(newData?.blockNumber);
     if (!isNaN(newNumber)) {
         blockNumber.value = newNumber;
     }
@@ -102,7 +102,7 @@ watch(() => props.data, (newData) => {
             </div>
             <div class="c-block-data__row-attribute">{{ $t('components.blocks.block_height') }}</div>
         </div>
-        <div class="c-block-data__col-val">
+        <div class="c-block-data__col-val c-block-data__col-val--block-number">
             <div class="c-block-data__row-value">{{ blockNumber }}</div>
             <div class="c-block-data__row-icon-btn c-block-data__row-icon-btn--left" @click="prevBlock">
                 <i class="fa fa-chevron-left small"></i>
@@ -337,6 +337,12 @@ watch(() => props.data, (newData) => {
         justify-content: left;
         align-items: baseline;
         gap: 5px;
+    }
+    &__col-val {
+        &--block-number {
+            display: flex;
+            align-items: center;
+        }
     }
     &__row {
         padding: 0.5rem 0;

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -5,7 +5,6 @@
 @import './components/notification';
 @import './components/q-layout';
 
-
 body {
     --top-bar-height: 48px;
     --bottom-bar-height: 52px;
@@ -100,3 +99,4 @@ a {
         }
     }
 }
+

--- a/src/css/global/_colors.scss
+++ b/src/css/global/_colors.scss
@@ -8,3 +8,6 @@ $grey: #909090;
 
 $tab-active-light: color-mix(in srgb, var(--q-primary), white 20%);
 $tab-active-dark: var(--q-primary);
+
+
+

--- a/src/css/global/_colors.scss
+++ b/src/css/global/_colors.scss
@@ -8,6 +8,3 @@ $grey: #909090;
 
 $tab-active-light: color-mix(in srgb, var(--q-primary), white 20%);
 $tab-active-dark: var(--q-primary);
-
-
-

--- a/src/css/global/global-index.scss
+++ b/src/css/global/global-index.scss
@@ -1,2 +1,5 @@
 @import 'colors';
 @import 'mixins';
+
+
+$latest-data-breakpoint: 600px;

--- a/src/pages/home/HomeInfo.vue
+++ b/src/pages/home/HomeInfo.vue
@@ -9,6 +9,7 @@ import { useI18n } from 'vue-i18n';
 import { useStore } from 'vuex';
 import { useQuasar } from 'quasar';
 
+import BlockField from 'components/BlockField.vue';
 import { indexerApi, telosApi } from 'src/boot/telosApi';
 
 const $store = useStore();
@@ -126,7 +127,11 @@ function updateFigures() {
             </span>
             <br>
             <q-skeleton v-if="latestBlock === 0" type="text" class="c-home-info__skeleton" />
-            <template v-else>{{ latestBlock }}</template>
+            <BlockField
+                v-else
+                class="c-home-info__number"
+                :block="latestBlock"
+            />
         </div>
 
         <q-separator class="q-my-md" />

--- a/src/pages/home/HomeLatestBlocks.vue
+++ b/src/pages/home/HomeLatestBlocks.vue
@@ -140,7 +140,7 @@ async function fetchBlocks() {
 
 function getPath(page = 0) {
     const offset = page * 100;
-    let path = `blocks?limit=3000&includeCount=true&offset=${offset}`;
+    let path = `blocks?limit=6&noEmpty=true&includeCount=true&offset=${offset}`;
     return path;
 }
 
@@ -242,7 +242,7 @@ onMounted(() => {
     &__number {
         margin-right:5px;
 
-        @media screen and (min-width: $breakpoint-lg-min) {
+        @media screen and (min-width: $latest-data-breakpoint) {
             margin-right: 0px;
             &::after {
                 content: ' ';
@@ -253,7 +253,7 @@ onMounted(() => {
 
     &__aux-text {
         display: none;
-        @media screen and (min-width: $breakpoint-lg-min) {
+        @media screen and (min-width: $latest-data-breakpoint) {
             display: block;
         }
     }
@@ -265,7 +265,7 @@ onMounted(() => {
             display: inline-block;
             margin-left: 10px;
         }
-        @media screen and (min-width: $breakpoint-lg-min) {
+        @media screen and (min-width: $latest-data-breakpoint) {
             &--desktop {
                 display: block;
             }

--- a/src/pages/home/HomeLatestBlocks.vue
+++ b/src/pages/home/HomeLatestBlocks.vue
@@ -140,7 +140,7 @@ async function fetchBlocks() {
 
 function getPath(page = 0) {
     const offset = page * 100;
-    let path = `blocks?limit=100&includeCount=true&offset=${offset}`;
+    let path = `blocks?limit=3000&includeCount=true&offset=${offset}`;
     return path;
 }
 

--- a/src/pages/home/HomeLatestBlocks.vue
+++ b/src/pages/home/HomeLatestBlocks.vue
@@ -140,7 +140,7 @@ async function fetchBlocks() {
 
 function getPath(page = 0) {
     const offset = page * 100;
-    let path = `blocks?limit=6&noEmpty=true&includeCount=true&offset=${offset}`;
+    let path = `blocks?limit=100&noEmpty=true&includeCount=true&offset=${offset}`;
     return path;
 }
 

--- a/src/pages/home/HomeLatestDataContainer.vue
+++ b/src/pages/home/HomeLatestDataContainer.vue
@@ -84,7 +84,7 @@ const showCustomize = computed(() => Object.keys(props.options).length > 1);
 <style lang="scss">
 .c-latest-data {
 
-    height: 550px;
+    height: 528px;
 
     &__header {
         &-title {
@@ -95,8 +95,6 @@ const showCustomize = computed(() => Object.keys(props.options).length > 1);
 
     &__content {
         overflow-y: auto;
-        max-height: 470px;
-
         @include scroll-bar;
     }
 

--- a/src/pages/home/HomeLatestDataTableRow.vue
+++ b/src/pages/home/HomeLatestDataTableRow.vue
@@ -58,11 +58,11 @@ defineProps<{
     gap: 2px;
     padding: 12px 0;
 
-    @media screen and (min-width: $breakpoint-lg-min) {
+    @media screen and (min-width: $latest-data-breakpoint) {
         gap: 12px;
     }
 
-    @media screen and (min-width: $breakpoint-lg-min) {
+    @media screen and (min-width: $latest-data-breakpoint) {
         flex-direction: row;
         align-items: center;
     }
@@ -71,7 +71,7 @@ defineProps<{
         #{$this}__column-one {
             display: none;
 
-            @media screen and (min-width: $breakpoint-lg-min) {
+            @media screen and (min-width: $latest-data-breakpoint) {
                 display: block;
             }
         }
@@ -98,7 +98,7 @@ defineProps<{
             background-color: $grey-9;
         }
 
-        @media screen and (min-width: $breakpoint-lg-min) {
+        @media screen and (min-width: $latest-data-breakpoint) {
             display: flex;
         }
     }
@@ -108,20 +108,20 @@ defineProps<{
     }
 
     &__column-two {
-        @media screen and (min-width: $breakpoint-lg-min) {
+        @media screen and (min-width: $latest-data-breakpoint) {
             width: 38%;
         }
     }
 
     &__column-three {
-        @media screen and (min-width: $breakpoint-lg-min) {
+        @media screen and (min-width: $latest-data-breakpoint) {
             width: 38%;
             flex-grow: 1;
         }
     }
 
     &__column-four {
-        @media screen and (min-width: $breakpoint-lg-min) {
+        @media screen and (min-width: $latest-data-breakpoint) {
             width: 20%;
             display: flex;
             justify-content: flex-end;

--- a/src/pages/home/HomeLatestTransactions.vue
+++ b/src/pages/home/HomeLatestTransactions.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeMount, ref } from 'vue';
+import { computed, onBeforeMount, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { BigNumber } from 'ethers/lib/ethers';
 
@@ -11,7 +11,9 @@ import DateField from 'components/DateField.vue';
 import TransactionField from 'components/TransactionField.vue';
 import AddressField from 'src/components/AddressField.vue';
 import HomeLatestDataTableRow from 'src/pages/home/HomeLatestDataTableRow.vue';
+import { useQuasar } from 'quasar';
 
+const $q = useQuasar();
 const $i18n = useI18n();
 const locale = $i18n.locale.value;
 const { t: $t } = $i18n;
@@ -27,6 +29,8 @@ interface Transaction {
 const transactions = ref<Transaction[]>([]);
 
 const loading = ref(true);
+
+const truncateHash = computed(() => $q.screen.width > 1024 && $q.screen.width <= 1240 ? 8 : 20);
 
 onBeforeMount(async () => {
     const response = await indexerApi.get('transactions?limit=6');
@@ -56,35 +60,42 @@ function getTlosValue(value: string) {
         </template>
 
         <template v-slot:column-two>
-            <TransactionField
-                class="c-home-latest-transactions__hash"
-                :transaction-hash="transactions[index].hash"
-            />
-            <DateField
-                class="c-home-latest-transactions__timestamp"
-                :epoch="transactions[index].timestamp / 1000"
-                :force-show-age="true"
-                :muted-text="true"
-            />
+            <div>
+                <TransactionField
+                    class="c-home-latest-transactions__hash"
+                    :transaction-hash="transactions[index].hash"
+                    :truncate="truncateHash"
+                />
+            </div>
+            <div>
+                <DateField
+                    class="c-home-latest-transactions__timestamp"
+                    :epoch="transactions[index].timestamp / 1000"
+                    :force-show-age="true"
+                    :muted-text="true"
+                />
+            </div>
         </template>
 
         <template v-slot:column-three>
-            {{ $t('pages.from') }}
-            <AddressField :address="transactions[index].from" :truncate="8" :hide-contract-icon="true" />
-            <br>
-            {{ $t('pages.to') }}
-            <AddressField
-                :address="transactions[index].to"
-                :truncate="8"
-                :hide-contract-icon="true"
-                :class="'c-home-latest-transactions__to-address'"
-            />
-
-            <div class="c-home-latest-transactions__value c-home-latest-transactions__value--mobile">
-                {{ getTlosValue(transactions[index].value) }}
-                <q-tooltip anchor="bottom right" self="top end">
-                    {{ $t('components.contract_tab.amount') }}
-                </q-tooltip>
+            <div class="c-home-latest-transactions__from-to">
+                {{ $t('pages.from') }}
+                <AddressField :address="transactions[index].from" :truncate="8" :hide-contract-icon="true" />
+            </div>
+            <div class="c-home-latest-transactions__from-to">
+                {{ $t('pages.to') }}
+                <AddressField
+                    :address="transactions[index].to"
+                    :truncate="8"
+                    :hide-contract-icon="true"
+                    :class="'c-home-latest-transactions__to-address'"
+                />
+                <div class="c-home-latest-transactions__value c-home-latest-transactions__value--mobile">
+                    {{ getTlosValue(transactions[index].value) }}
+                    <q-tooltip anchor="bottom right" self="top end">
+                        {{ $t('components.contract_tab.amount') }}
+                    </q-tooltip>
+                </div>
             </div>
         </template>
 
@@ -106,7 +117,7 @@ function getTlosValue(value: string) {
     &__hash {
         margin-right:5px;
 
-        @media screen and (min-width: $breakpoint-lg-min) {
+        @media screen and (min-width: $latest-data-breakpoint) {
             margin-right: 0px;
             &::after {
                 content: ' ';
@@ -138,6 +149,16 @@ function getTlosValue(value: string) {
         }
     }
 
+    &__from-to {
+        // display: flex;
+        // align-items: center;
+        // gap: 5px;
+        // margin-bottom: 5px;
+
+        // no break
+        white-space: nowrap;
+    }
+
     &__value {
         @include token-value;
         display: none;
@@ -145,7 +166,7 @@ function getTlosValue(value: string) {
             display: inline-block;
             margin-left: 10px;
         }
-        @media screen and (min-width: $breakpoint-lg-min) {
+        @media screen and (min-width: $latest-data-breakpoint) {
             &--desktop {
                 display: block;
             }


### PR DESCRIPTION
# Fixes #623

## Description
- The parameter noEmpty=true was added to the block query. When this parameter works, the frontend will adapt on its own.
- The number of the last mined block is now a link to the block page.
- The margins of the latest-data box were adjusted.
- On the block page, the number was not being fetched correctly. It showed a 0, and now it displays the correct value.



<!---
Include a summary of your change and how it solves the issue its related to
-->

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage
-   [x] I have updated relevant documentation and/or opened a separate issue to cover the updates (Issue URL: )
