### PR TITLE
#625 | Closing qr popup scrolls the page on chrome

### DIFF
--- a/src/components/AddressQR.vue
+++ b/src/components/AddressQR.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { nextTick, onMounted, ref } from 'vue';
 import QRious from 'qrious';
+import { watch } from 'vue';
 
 const props = defineProps({
     address: {
@@ -31,6 +32,26 @@ onMounted(() => {
         value: props.address,
     });
 });
+
+watch(showCode, (value) => {
+    // This is a workaround for the issue with the dialog not scrolling to the top
+    // https://github.com/telosnetwork/teloscan/issues/625
+    if (!value) {
+        // what for the scroll and if it moves, correct it and end
+        const timer = setInterval(() => {
+            if (window.scrollY > 0) {
+                window.scrollTo({ top: 0, behavior: 'instant' });
+                clearInterval(timer);
+            }
+        }, 0);
+        // avoid the interval to run forever
+        setTimeout(() => {
+            window.scrollTo({ top: 0, behavior: 'instant' });
+            clearInterval(timer);
+        }, 100);
+    }
+});
+
 
 </script>
 


### PR DESCRIPTION
# Fixes #625 

[Test link](https://deploy-preview-626--teloscan-redesign-mainnet.netlify.app/address/0xA10165F5fAe1975Badb16B1d9efC62F5b6aceb8c)

## Description

This PR adds a workaround to the problem of the QR popup scrolling the page when it's closed.

I couldn't determine the cause of this problem so I couldn't fix the problem. The page still scrolls down when the popup is closed but now is immediately restored. However, you can notice a no-desired block effect.

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage
-   [x] I have updated relevant documentation and/or opened a separate issue to cover the updates (Issue URL: )
