### PR TITLE
#646 | walletstaking link for testnet links to mainnet wallet

### DIFF
--- a/src/components/header/AppHeaderLinks.vue
+++ b/src/components/header/AppHeaderLinks.vue
@@ -36,6 +36,14 @@ const teloscanSwaggerUrl = IS_MAINNET
     ? 'https://api.teloscan.io/v1/docs'
     : 'https://api.testnet.teloscan.io/v1/docs';
 
+const telosWalletUrl = IS_MAINNET
+    ? 'https://wallet.telos.net/'
+    : 'https://wallet-dev.telos.net/';
+
+const telosBridgeUrl = IS_MAINNET
+    ? 'https://bridge.telos.net/bridge'
+    : 'https://telos-bridge-testnet.netlify.app/bridge';
+
 const developersSubmenuItems = [
     {
         url: teloscanSwaggerUrl,
@@ -48,13 +56,13 @@ const developersSubmenuItems = [
 ];
 
 const telos_walletMenuItem = {
-    url: 'https://wallet.telos.net/',
+    url: telosWalletUrl,
     label: `${$t('components.header.telos_wallet')}/Staking`,
 };
 
 
 const telos_bridgeMenuItem = {
-    url: 'https://bridge.telos.net/bridge',
+    url: telosBridgeUrl,
     label: $t('components.header.telos_bridge'),
 };
 


### PR DESCRIPTION
# Fixes #646 

## Description

This PR put Testnet links on the app header when running the app on Testnet. This involves the wallet and the bridge.

## Test scenarios
- Go to [this link (Testnet)](https://deploy-preview-660--teloscan-redesign.netlify.app/)
- click on Wallet/Stake
  - it should redirect you to the Testnet version of the wallet
- click on Bridge link
  - it should redirect you to the Testnet version of the bridge



## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage
-   [x] I have updated relevant documentation and/or opened a separate issue to cover the updates (Issue URL: )
