### PR TITLE
#673 | Light mode by default

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -23,7 +23,7 @@ const margin = ref(50);
 const onHomePage = computed(() => $route.name === 'home');
 
 onBeforeMount(() => {
-    $q.dark.set(localStorage.getItem('darkModeEnabled') !== 'false');
+    $q.dark.set(localStorage.getItem('darkModeEnabled') === 'true');
 });
 
 onMounted(() => {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -22,8 +22,19 @@ const margin = ref(50);
 
 const onHomePage = computed(() => $route.name === 'home');
 
+
 onBeforeMount(() => {
-    $q.dark.set(localStorage.getItem('darkModeEnabled') === 'true');
+    const $q = useQuasar();
+    const storedDarkMode = localStorage.getItem('darkModeEnabled');
+
+    // Check if 'darkModeEnabled' is in localStorage
+    if (storedDarkMode !== null) {
+        $q.dark.set(storedDarkMode === 'true');
+    } else {
+        // Use system preferences if there is no preference saved
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        $q.dark.set(prefersDark);
+    }
 });
 
 onMounted(() => {


### PR DESCRIPTION
# Fixes #673

## Description
This PR sets the dark mode as the default

## Test scenarios
- Open [This link.](https://deploy-preview-683--testnet-teloscan.netlify.app/)
- clean the cache
- refresh the page
  - the Light/Dark mode should be the same as your browser settings
