### PR TITLE
#684 | improve error reporting notification

### DIFF
--- a/src/antelope/mocks/AccountStore.ts
+++ b/src/antelope/mocks/AccountStore.ts
@@ -11,9 +11,6 @@ import { useFeedbackStore } from 'src/antelope/mocks';
 import { EvmABI, EvmFunctionParam, Label, TransactionResponse } from 'src/antelope/types';
 import { subscribeForTransactionReceipt } from 'src/antelope/wallets/utils/trx-utils';
 
-export const errorToString = (error: unknown) =>
-    getAntelope().config.errorToStringHandler(error);
-
 export interface AccountModel {
     label: typeof CURRENT_CONTEXT;
     isNative: boolean;
@@ -145,7 +142,7 @@ class AccountStore {
             const authenticator = useAccountStore().getAccount(label)?.authenticator as EVMAuthenticator;
             return authenticator.isConnectedToCorrectChain();
         } catch (error) {
-            console.error('Error: ', errorToString(error));
+            console.error('Error: ', error);
             return Promise.resolve(false);
         } finally {
             useFeedbackStore().unsetLoading('account.isConnectedToCorrectNetwork');

--- a/src/antelope/mocks/AntelopeConfig.ts
+++ b/src/antelope/mocks/AntelopeConfig.ts
@@ -79,6 +79,7 @@ export class AntelopeConfig {
             type EVMError = {code:string};
             const evmErr = error as EVMError;
 
+            // high priority generic errors
             switch (evmErr.code) {
             case 'CALL_EXCEPTION':          return 'antelope.evm.error_call_exception';
             case 'INSUFFICIENT_FUNDS':      return 'antelope.evm.error_insufficient_funds';
@@ -87,7 +88,6 @@ export class AntelopeConfig {
             case 'NUMERIC_FAULT':           return 'antelope.evm.error_numeric_fault';
             case 'REPLACEMENT_UNDERPRICED': return 'antelope.evm.error_replacement_underpriced';
             case 'TRANSACTION_REPLACED':    return 'antelope.evm.error_transaction_replaced';
-            case 'UNPREDICTABLE_GAS_LIMIT': return 'antelope.evm.error_unpredictable_gas_limit';
             case 'USER_REJECTED':           return 'antelope.evm.error_user_rejected';
             case 'ACTION_REJECTED':         return 'antelope.evm.error_transaction_canceled';
             }
@@ -128,6 +128,11 @@ export class AntelopeConfig {
                 if (messageFound !== 'unknown') {
                     return messageFound;
                 }
+            }
+
+            // low priority generic errors
+            switch (evmErr.code) {
+            case 'UNPREDICTABLE_GAS_LIMIT': return 'antelope.evm.error_unpredictable_gas_limit';
             }
 
             if (typeof error === 'string') {

--- a/src/boot/errorHandling.js
+++ b/src/boot/errorHandling.js
@@ -124,6 +124,15 @@ const notifyMessage = function(type, icon, title, message, payload, remember = '
                 }
             }
 
+            // If the content is a valid JSON, it should be possible to parse it and re stringify it using a pretty format
+            try {
+                const parsed = JSON.parse(content);
+                content = JSON.stringify(parsed, null, 4);
+                content = `<pre>${content}</pre>`;
+            } catch (e) {
+                // If it fails, we discard the error and use the original content
+            }
+
             Dialog.create({
                 class: 'c-notify__dialog',
                 title: this.$t('notification.error_details_title'),

--- a/src/boot/fathom.js
+++ b/src/boot/fathom.js
@@ -1,0 +1,16 @@
+import { boot } from 'quasar/wrappers';
+
+export default boot(() => {
+    const script = document.createElement('script');
+    script.src = 'https://cdn.usefathom.com/script.js';
+
+    // VMVLEWFD for mainnet
+    // HKAXCRJB for testnet
+    script.dataset.site = 'ISPYEAKT';
+    script.dataset.spa = 'auto';
+    script.defer = true;
+    document.body.appendChild(script);
+
+    console.log('Fathom installed !!!'); // FIXME: remove this line
+});
+

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -521,7 +521,7 @@ export default {
         try_reloading: 'You can try reloading the page to fix it, if the problem persist please contact a Telos team member.',
         error: 'Error',
         expand: 'See more ({more})',
-        async_error_description: 'Sorry ! An error occured trying to request resources. Please make sure your internet connection is working and try again. If the error persists, contact us directly on our Telegram channel.',
+        async_error_description: 'Sorry ! An error occurred trying to request resources. Please make sure your internet connection is working and try again. If the error persists, contact us directly on our Telegram channel.',
         language: 'Language',
         cancel: 'Cancel',
         ok: 'Ok',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -544,7 +544,7 @@ export default {
         success_message_copied: 'Your account name has been copied to the clipboard.',
         success_see_trx_label: 'See Transaction',
         dismiss_label: 'Dismiss',
-        error_title: 'ooops',
+        error_title: 'Error',
         error_title_disconnect: 'No Internet connection',
         error_message_disconnect: 'We\'re sorry, it looks like you\'re not connected to the internet. Please check your network connection and try again.',
         error_see_details_label: 'See Details',

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -109,6 +109,18 @@ const routes = [
         redirect: () => ({ path: '/health' }),
     },
     {
+        // if the user falls on a /staking path, we need to redirect the user to https://wallet.telos.net/evm/staking?tab=stake
+        path: '/staking',
+        component: () => import('layouts/MainLayout.vue'),
+        hildren: [{
+            path: '',
+            component: () => import('pages/ErrorNotFoundPage.vue'),
+        }],
+        beforeEnter() {
+            window.location.href = 'https://wallet.telos.net/evm/staking?tab=stake';
+        },
+    },
+    {
         path: '/:catchAll(.*)*',
         component: () => import('layouts/MainLayout.vue'),
         children: [{


### PR DESCRIPTION
# Fixes #684 

## Description
This PR changes the function to manage error messages:
- First, it tries to see if the error code is something known to be treated in a special way (like when you cancel from the wallet).
- If not, then it tries to extract the reason or the message from the error object. It uses the deepest option in the case of having multiple message attributes
- Finally, it tries to 
Change OOOPS to Error


![image](https://github.com/telosnetwork/teloscan/assets/4420760/d68407ef-4a67-4b84-9fdf-1da020e4eb00)
![image](https://github.com/telosnetwork/teloscan/assets/4420760/69d28181-1692-4676-8c92-8a5a6eb935c1)


