### PR TITLE
#687 | transaction page erc20 transfers on overview tab are missing

### DIFF
--- a/src/components/Transaction/ERCTransferList.vue
+++ b/src/components/Transaction/ERCTransferList.vue
@@ -150,7 +150,7 @@ const getValueDisplay = (value: string, symbol: string, decimals: number) =>
         false,
         symbol,
         false,
-        decimals,
+        typeof decimals === 'string' ? parseInt(decimals) : decimals,
         false,
     );
 


### PR DESCRIPTION
# Fixes #687 

## Description
This PR fixes the broken section of erc20 transfers in a Transaction

## Test scenarios
- go and see [this transaction](https://deploy-preview-690--teloscan.netlify.app/tx/0x37a18e059f6765dc4d2e5bd24e0cbe3f2a4e752934522a6f02a292ec023f8913?tab=transactions)
   - you should see the ERC20 Tranfers