### PR TITLE
#686 | address page erc20 transfers tab value formatting

### DIFF
--- a/src/components/NftTransfersTable.vue
+++ b/src/components/NftTransfersTable.vue
@@ -259,23 +259,6 @@ const onRequest = async (settings: { pagination: Pagination}) => {
     loading.value = false;
 };
 
-/*
-const locale = useI18n().locale.value;
-function getValueDisplay(value: string, symbol: string, decimals: number) {
-    const _decimals = typeof decimals === 'number' ? decimals : parseInt(decimals ?? WEI_PRECISION);
-    return prettyPrintCurrency(
-        BigNumber.from(value),
-        4,
-        locale,
-        false,
-        symbol ?? 'UNKNOWN',
-        false,
-        _decimals,
-        false,
-    );
-}
-*/
-
 const locale = useI18n().locale.value;
 function getValueDisplay(value: string, symbol: string, decimals: number) {
     const _decimals = typeof decimals === 'number' ? decimals : parseInt(decimals ?? WEI_PRECISION);

--- a/src/components/NftTransfersTable.vue
+++ b/src/components/NftTransfersTable.vue
@@ -14,6 +14,9 @@ import { formatWei, toChecksumAddress } from 'src/lib/utils';
 import { EvmTransactionExtended, Pagination } from 'src/types';
 
 import { loadTransaction } from 'src/lib/transaction-utils';
+import { WEI_PRECISION } from 'src/antelope/wallets/utils';
+import { BigNumber } from 'ethers';
+import { prettyPrintCurrency } from 'src/antelope/wallets/utils/currency-utils';
 
 const { t: $t } = useI18n();
 
@@ -256,6 +259,46 @@ const onRequest = async (settings: { pagination: Pagination}) => {
     loading.value = false;
 };
 
+/*
+const locale = useI18n().locale.value;
+function getValueDisplay(value: string, symbol: string, decimals: number) {
+    const _decimals = typeof decimals === 'number' ? decimals : parseInt(decimals ?? WEI_PRECISION);
+    return prettyPrintCurrency(
+        BigNumber.from(value),
+        4,
+        locale,
+        false,
+        symbol ?? 'UNKNOWN',
+        false,
+        _decimals,
+        false,
+    );
+}
+*/
+
+const locale = useI18n().locale.value;
+function getValueDisplay(value: string, symbol: string, decimals: number) {
+    const _decimals = typeof decimals === 'number' ? decimals : parseInt(decimals ?? WEI_PRECISION);
+    console.log('getValueDisplay', value, symbol, decimals, '[', _decimals, ']');
+    try {
+        return prettyPrintCurrency(
+            BigNumber.from(value.split('.').join('')),
+            4,
+            locale,
+            false,
+            symbol ?? 'UNKNOWN',
+            false,
+            _decimals,
+            false,
+        );
+    } catch (e) {
+        console.error('getValueDisplay', e);
+    }
+
+    return truncatedId(value);
+}
+
+
 const convertToEpoch = (dateString: string | number) => {
     if (typeof dateString === 'number'){
         return dateString / 1000;
@@ -432,7 +475,7 @@ onMounted(() => {
             </q-td>
             <q-td key="value" :props="props">
                 <span>
-                    {{ truncatedId(props.row.value) }}
+                    {{ getValueDisplay(props.row.value, props.row.contract.symbol, props.row.contract.decimals) }}
                     <q-tooltip>{{ props.row.value }}</q-tooltip>
                 </span>
             </q-td>

--- a/src/components/NftTransfersTable.vue
+++ b/src/components/NftTransfersTable.vue
@@ -457,7 +457,7 @@ onMounted(() => {
                 </span>
             </q-td>
             <q-td key="value" :props="props">
-                <span>
+                <span class="value">
                     {{ getValueDisplay(props.row.value, props.row.contract.symbol, props.row.contract.decimals) }}
                     <q-tooltip>{{ props.row.value }}</q-tooltip>
                 </span>
@@ -572,6 +572,13 @@ onMounted(() => {
 
 .info-icon{
     margin-left: .25rem;
+}
+
+.value {
+    max-width: 175px;
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 </style>

--- a/src/components/Transaction/ERCTransferList.vue
+++ b/src/components/Transaction/ERCTransferList.vue
@@ -150,7 +150,7 @@ const getValueDisplay = (value: string, symbol: string, decimals: number) =>
         false,
         symbol,
         false,
-        decimals,
+        typeof decimals === 'string' ? parseInt(decimals) : decimals,
         false,
     );
 


### PR DESCRIPTION
# Fixes #686

## Description
This PR fixes the display of the value for the ERC20 Transfers tab.

## Test scenarios
- https://deploy-preview-694--dev-mainnet-teloscan.netlify.app/address/0xA25bc8c1e230a476cB00f2e9c93ffC2D4e163dc5?tab=tokentxns
- https://deploy-preview-694--dev-mainnet-teloscan.netlify.app/address/0x9728f7772f95a7346c22C831Ff6bAC565662d8dA?tab=tokentxns

![image](https://github.com/telosnetwork/teloscan/assets/4420760/4d3db683-dfe0-4fe3-b262-897b95e15190)

**Note:** There is a problem with the symbol that replicates in two different places. The problem is described in this separate issue: https://github.com/telosnetwork/teloscan/issues/693