### PR TITLE
#672 | Show deployed contract in contract deployment transactions

### DIFF
--- a/solidity/README.md
+++ b/solidity/README.md
@@ -1,0 +1,3 @@
+# Description
+
+This folder is meant to hold all the contract examples deployed on Testnet and Mainnet that we need to test specific features difficult to find in the normal set of contracts. This way we may have more control of what we are testing.

--- a/solidity/SimpleCounterManager/README.md
+++ b/solidity/SimpleCounterManager/README.md
@@ -1,0 +1,1 @@
+This contract was deployed on Testnet in 0x9ac5Eb8930ee9E4c5106F421708a4d2FCC146286 but I could not verify it.

--- a/solidity/SimpleCounterManager/SimpleCounterManager.sol
+++ b/solidity/SimpleCounterManager/SimpleCounterManager.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+contract SimpleCounterManager {
+    uint256 public count;
+
+    // Error for handling validation logic
+    error NotAllowed(string message);
+
+    // Increments count if the parameter is false. If true, emits an error.
+    function checkAndIncrementCount(bool flag) public {
+        if (flag) {
+            revert NotAllowed("Flag is true, operation not allowed");
+        } else {
+            count += 1;
+        }
+    }
+
+    // Verifies if msg.sender is the owner of the NFT and, if true, increments count
+    function verifyOwnerAndIncrement(uint256 tokenId, address contractAddress) public {
+        IERC721 nftContract = IERC721(contractAddress);
+        address owner = nftContract.ownerOf(tokenId);
+        if (msg.sender != owner) {
+            revert NotAllowed("Caller is not the owner of the NFT");
+        } else {
+            count += 1;
+        }
+    }
+
+    // Resets the count variable to 0
+    function resetCount() public {
+        count = 0;
+    }
+}

--- a/solidity/SimpleCounterManager/SimpleCounterManager_metadata.json
+++ b/solidity/SimpleCounterManager/SimpleCounterManager_metadata.json
@@ -1,0 +1,124 @@
+{
+	"compiler": {
+		"version": "0.8.20+commit.a1b79de6"
+	},
+	"language": "Solidity",
+	"output": {
+		"abi": [
+			{
+				"inputs": [
+					{
+						"internalType": "string",
+						"name": "message",
+						"type": "string"
+					}
+				],
+				"name": "NotAllowed",
+				"type": "error"
+			},
+			{
+				"inputs": [
+					{
+						"internalType": "bool",
+						"name": "flag",
+						"type": "bool"
+					}
+				],
+				"name": "checkAndIncrementCount",
+				"outputs": [],
+				"stateMutability": "nonpayable",
+				"type": "function"
+			},
+			{
+				"inputs": [],
+				"name": "count",
+				"outputs": [
+					{
+						"internalType": "uint256",
+						"name": "",
+						"type": "uint256"
+					}
+				],
+				"stateMutability": "view",
+				"type": "function"
+			},
+			{
+				"inputs": [],
+				"name": "resetCount",
+				"outputs": [],
+				"stateMutability": "nonpayable",
+				"type": "function"
+			},
+			{
+				"inputs": [
+					{
+						"internalType": "uint256",
+						"name": "tokenId",
+						"type": "uint256"
+					},
+					{
+						"internalType": "address",
+						"name": "contractAddress",
+						"type": "address"
+					}
+				],
+				"name": "verifyOwnerAndIncrement",
+				"outputs": [],
+				"stateMutability": "nonpayable",
+				"type": "function"
+			}
+		],
+		"devdoc": {
+			"kind": "dev",
+			"methods": {},
+			"version": 1
+		},
+		"userdoc": {
+			"kind": "user",
+			"methods": {},
+			"version": 1
+		}
+	},
+	"settings": {
+		"compilationTarget": {
+			"contracts/SimpleCounterManager.sol": "SimpleCounterManager"
+		},
+		"evmVersion": "shanghai",
+		"libraries": {},
+		"metadata": {
+			"bytecodeHash": "ipfs"
+		},
+		"optimizer": {
+			"enabled": false,
+			"runs": 200
+		},
+		"remappings": []
+	},
+	"sources": {
+		"@openzeppelin/contracts/token/ERC721/IERC721.sol": {
+			"keccak256": "0x5ef46daa3b58ef2702279d514780316efaa952915ee1aa3396f041ee2982b0b4",
+			"license": "MIT",
+			"urls": [
+				"bzz-raw://2f8f2a76e23b02fc69e8cd24c3cb47da6c7af3a2d6c3a382f8ac25c6e094ade7",
+				"dweb:/ipfs/QmPV4ZS4tPVv4mTCf9ejyZ1ai57EEibDRj7mN2ARDCLV5n"
+			]
+		},
+		"@openzeppelin/contracts/utils/introspection/IERC165.sol": {
+			"keccak256": "0x4296879f55019b23e135000eb36896057e7101fb7fb859c5ef690cf14643757b",
+			"license": "MIT",
+			"urls": [
+				"bzz-raw://87b3541437c8c443ccd36795e56a338ed12855eec17f8da624511b8d1a7e14df",
+				"dweb:/ipfs/QmeJQCtZrQjtJLr6u7ZHWeH3pBnjtLWzvRrKViAi7UZqxL"
+			]
+		},
+		"contracts/SimpleCounterManager.sol": {
+			"keccak256": "0x270afa70141f5f5169a44591711ddb41195d2e26fde8fea153212116cad06f1d",
+			"license": "MIT",
+			"urls": [
+				"bzz-raw://908f6b929981054457ea92f1e258af783cb26cfb130ef114ffc9cbc3712b4d7a",
+				"dweb:/ipfs/QmW4TXBpfvDzT8LG5CMKMsGHz1GNcQ5tHbPWE8WbKbTSBr"
+			]
+		}
+	},
+	"version": 1
+}

--- a/src/components/AddressField.vue
+++ b/src/components/AddressField.vue
@@ -161,7 +161,6 @@ function emitHighlight(val: string) {
 
 <style lang="scss">
 .c-address-field {
-    min-width: 140px;
     display: inline-flex;
     align-items: center;
     gap: 4px;


### PR DESCRIPTION
# Fixes #672

## Description
This PR changes the way we display transactions for Contract Deployments

**Note**: This PR also introduces a new folder to start adding all solidity contracts that we may need to test any functionality. This way we can control and recreate all the situations we need and reuse old examples. 

## Test scenarios
- https://deploy-preview-695--testnet-teloscan.netlify.app/tx/0x5df4473bd7ae4304280c794f8147b53c9a83a26b8396ad04dc78f035dbd6eddd
- https://deploy-preview-695--testnet-teloscan.netlify.app/tx/0x9ce49f2b30520a6327e4aa4971e597b9823543333e6d85f5b2abf86558ac296b


## Screens

![image](https://github.com/telosnetwork/teloscan/assets/4420760/b716cf1e-5277-4b95-8d3c-b017ff4fb2a8)
