### PR TITLE
make token icon circles consistently in account page

### DIFF
--- a/src/pages/AccountPage.vue
+++ b/src/pages/AccountPage.vue
@@ -433,6 +433,7 @@ async function loadAccount() {
     &__coin-icon {
         width: 24px;
         height: 24px;
+        border-radius: 100%;
     }
 
     &__panels {


### PR DESCRIPTION
This just adds a `border-radius:100%` to the token icon in the account page header