### PR TITLE
#726 | Txn Fee header is shorter

### DIFF
--- a/src/components/TransactionTable.vue
+++ b/src/components/TransactionTable.vue
@@ -116,7 +116,7 @@ const columns = [
     },
     {
         name: 'fee',
-        label: `${$t('components.txn_fee')} (TLOS)`,
+        label: `${$t('components.txn_fee')}`,
         align: 'right',
     },
 ];


### PR DESCRIPTION
# Fixes #726 

## Description
This PR makes the Txn fee column header shorter.

## Test scenarios
- https://deploy-preview-729--teloscan-stage.netlify.app/address/0x62FDf8A96FD134fa7A22b7D3A6D4D5411D063432
![image](https://github.com/telosnetwork/teloscan/assets/4420760/0d9c7de0-e517-4027-b771-4622f6f4b714)
