### PR TITLE
#567 | contract internal transactions page

### DIFF
--- a/src/components/AddressField.vue
+++ b/src/components/AddressField.vue
@@ -90,6 +90,7 @@ const getDisplay = async () => {
         return;
     }
     let address = toChecksumAddress(props.address);
+    fullName.value = address;
     if (contractName.value) {
         if(tokenList.value?.tokens){
             tokenList.value.tokens.forEach((token: any) => {

--- a/src/components/InternalTransactionFlatTable.vue
+++ b/src/components/InternalTransactionFlatTable.vue
@@ -45,47 +45,47 @@ export default {
         const columns = [
             {
                 name: 'hash',
-                label: '',
+                label: 'hash',
                 align: 'left',
             },
             {
                 name: 'block',
-                label: '',
+                label: 'block',
                 align: 'left',
             },
             {
                 name: 'date',
-                label: '',
+                label: 'date',
                 align: 'left',
             },
             {
                 name: 'type',
-                label: '',
+                label: 'type',
                 align: 'left',
             },
             {
                 name: 'from',
-                label: '',
+                label: 'from',
                 align: 'left',
             },
             {
                 name: 'direction',
-                label: '',
+                label: 'direction',
                 align: 'left',
             },
             {
                 name: 'to',
-                label: '',
+                label: 'to',
                 align: 'left',
             },
             {
                 name: 'value',
-                label: '',
+                label: 'value',
                 align: 'right',
             },
             {
                 name: 'count',
-                label: '',
+                label: 'count',
                 align: 'right',
             },
         ];

--- a/src/components/InternalTransactionFlatTable.vue
+++ b/src/components/InternalTransactionFlatTable.vue
@@ -106,7 +106,7 @@ export default {
             },
             page_size_options: [10, 20, 50],
             showDateAge: true,
-            allExpanded: true,
+            allExpanded: false,
         };
     },
     async created() {

--- a/src/components/Token/TokenTable.vue
+++ b/src/components/Token/TokenTable.vue
@@ -54,9 +54,6 @@ export default {
     },
     methods: {
         ...mapActions('general', ['toggleDisplayDecimals']),
-        async showEntry(token) {
-            console.log('showEntry', token);
-        },
     },
 };
 </script>
@@ -94,7 +91,7 @@ export default {
     </template>
 
     <template v-slot:body="props">
-        <q-tr :props="props" @click="showEntry(props.row)">
+        <q-tr :props="props">
             <q-td key="icon" :props="props">
                 <q-img :src="props.row.logoURI" class="c-token-icon" />
             </q-td>

--- a/src/components/ValueField.vue
+++ b/src/components/ValueField.vue
@@ -44,6 +44,8 @@ function updateLocalVariables() {
 
         if (local_value.indexOf('.') === -1) {
             // if local_value has the format xxxxxxxxxxxyyyyyyyyyyyyyy
+
+            local_value = '0'.repeat(WEI_PRECISION) + local_value; // -> 0000000000xxxxxxxx.yyyyyyyyyyyyyy
             local_value = [
                 local_value.slice(0, local_value.length - local_decimals), // xxxxxxxxxxx
                 local_value.slice(local_value.length - local_decimals),    // yyyyyyyyyyyyyy
@@ -103,7 +105,7 @@ function updateLocalVariables() {
             false,
             local_decimals,
             false,
-        ).trim().replace(/(\.\d[1-9]*)(0+$)/, '$1')+ ' ' + (props.symbol ?? '');
+        ).trim().replace(/(\.\d*?[1-9])0+$|\.0+$/, '$1');
     } catch (e) {
         console.error('getValueDisplay', e);
     }

--- a/src/components/header/AppHeaderLinks.vue
+++ b/src/components/header/AppHeaderLinks.vue
@@ -26,6 +26,7 @@ const emit = defineEmits(['close-menu']);
 
 
 const blockchainSubmenuItems = [
+    { name: 'txsinternal', label: $t('components.header.internal_transactions') },
     { name: 'transactions', label: $t('components.header.transactions') },
     { name: 'blocks', label: $t('components.header.blocks') },
 ];

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -28,6 +28,8 @@ body.body--light {
     --scrollbar-track-bg-color: #{$grey-5};
     --scrollbar-thumb-bg-color: #{$grey-7};
 
+    --odd-row-bg-color: #{$grey-3};
+
     a:hover {
         color: $a-hover-light;
     }
@@ -48,6 +50,8 @@ body.body--dark {
 
     --scrollbar-track-bg-color: #{$grey-10};
     --scrollbar-thumb-bg-color: #{$grey-7};
+
+    --odd-row-bg-color: #{$grey-10};
 
     --q-dark: #181818;
 

--- a/src/css/global/_mixins.scss
+++ b/src/css/global/_mixins.scss
@@ -17,6 +17,9 @@
         font-size: 1.4rem;
         font-weight: bold;
     }
+    &-sub-title {
+        font-size: 1rem;
+    }
 }
 
 @mixin page-header-nav-btn {

--- a/src/css/global/_mixins.scss
+++ b/src/css/global/_mixins.scss
@@ -8,17 +8,14 @@
 
 @mixin page-header {
     display: flex;
+    flex-direction: column;
     justify-content: left;
-    gap: 10px;
     align-items: baseline;
     margin-bottom: 1.5rem;
     vertical-align: text-bottom;
     &-title {
         font-size: 1.4rem;
         font-weight: bold;
-    }
-    &-sub-title {
-        font-size: 1rem;
     }
 }
 
@@ -141,4 +138,11 @@
         background: rgba(148, 148, 148, 0.1);
         border: 1px solid #949494 !important;
     }
+
+    &.to {
+        color: rgb(0, 131, 164);
+        background: rgba(0, 134, 161, 0.1);
+        border: 1px solid rgb(0, 134, 161);
+    }
+
 }

--- a/src/i18n/de-de/index.js
+++ b/src/i18n/de-de/index.js
@@ -434,6 +434,7 @@ export default {
             telos_wallet: 'Wallet',
             telos_bridge: 'Bridge',
             transactions: 'Transaktionen',
+            internal_transactions: 'Internal Transactions',
             verify_contract_sourcify: 'Vertrag überprüfen (Sourcify)',
             view_other_networks: 'Andere Netzwerke anzeigen',
         },

--- a/src/i18n/de-de/index.js
+++ b/src/i18n/de-de/index.js
@@ -137,6 +137,7 @@ export default {
         input: 'Eingabe',
         output: 'Ausgabe',
         value: 'Wert',
+        count: 'Anzahl',
         overview: 'Übersicht',
         more_info: 'mehr Infos',
         transaction_sent: 'txn gesendet',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -44,6 +44,7 @@ export default {
         },
         internaltrx: {
             page_title: 'Contract Internal Transactions',
+            for_address: 'for address { address }',
         },
         home: {
             telos_evm_explorer: 'The Telos EVM Explorer',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -42,6 +42,9 @@ export default {
             internal: 'Internal Transactions',
             not_found: 'Transaction not found',
         },
+        internaltrx: {
+            page_title: 'Contract Internal Transactions',
+        },
         home: {
             telos_evm_explorer: 'The Telos EVM Explorer',
             market_cap: 'Market Cap',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -139,6 +139,7 @@ export default {
         input: 'Input',
         output: 'Output',
         value: 'Value',
+        count: 'Count',
         overview: 'overview',
         more_info: 'more info',
         transaction_sent: 'txn sent',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -449,6 +449,7 @@ export default {
             telos_wallet: 'Wallet',
             telos_bridge: 'Bridge',
             transactions: 'Transactions',
+            internal_transactions: 'Internal Transactions',
             verify_contract_sourcify: 'Verify Contract (Sourcify)',
             view_other_networks: 'View other networks',
         },

--- a/src/i18n/es-es/index.js
+++ b/src/i18n/es-es/index.js
@@ -435,6 +435,7 @@ export default {
             telos_wallet: 'Wallet',
             telos_bridge: 'Bridge',
             transactions: 'Transacciones',
+            internal_transactions: 'Transacciones internas',
             verify_contract_sourcify: 'Verificar Contrato (Sourcify)',
             view_other_networks: 'Ver otras redes',
         },

--- a/src/i18n/es-es/index.js
+++ b/src/i18n/es-es/index.js
@@ -137,6 +137,7 @@ export default {
         input: 'Entrada',
         output: 'Salida',
         value: 'Valor',
+        count: 'Cuenta',
         overview: 'visión general',
         more_info: 'más información',
         transaction_sent: 'txn enviado',

--- a/src/i18n/fr-fr/index.js
+++ b/src/i18n/fr-fr/index.js
@@ -411,6 +411,7 @@ export default {
             telos_wallet: 'Wallet',
             telos_bridge: 'Bridge',
             transactions: 'Transactions',
+            internal_transactions: 'Transactions internes',
             verify_contract_sourcify: 'Vérifier le Contrat (Sourcify)',
             view_other_networks: 'Voir d\'autres réseaux',
         },

--- a/src/i18n/fr-fr/index.js
+++ b/src/i18n/fr-fr/index.js
@@ -141,6 +141,7 @@ export default {
         input: 'Entrée',
         output: 'Sortie',
         value: 'Valeur',
+        count: 'Montant',
         overview: 'aperçu',
         more_info: 'plus d\'info',
         transaction_sent: 'txn envoyé',

--- a/src/i18n/pt-br/index.js
+++ b/src/i18n/pt-br/index.js
@@ -434,6 +434,7 @@ export default {
             telos_wallet: 'Wallet',
             telos_bridge: 'Bridge',
             transactions: 'Transações',
+            internal_transactions: 'Transações Internas',
             verify_contract_sourcify: 'Verificar Contrato (Sourcify)',
             view_other_networks: 'Visualizar outras redes',
         },

--- a/src/i18n/pt-br/index.js
+++ b/src/i18n/pt-br/index.js
@@ -137,6 +137,7 @@ export default {
         input: 'Entrada',
         output: 'Saída',
         value: 'Valor',
+        count: 'Cuenta',
         overview: 'visão geral',
         more_info: 'mais informações',
         transaction_sent: 'txn enviado',

--- a/src/lib/contract/ContractManager.js
+++ b/src/lib/contract/ContractManager.js
@@ -156,6 +156,10 @@ export default class ContractManager {
             return;
         }
         let index = address.toString().toLowerCase();
+        if (contractData === null) {
+            this.contracts[index] = null;
+            return;
+        }
         let contract = this.factory.buildContract(contractData);
         if(
             typeof this.contracts[index] === 'undefined'
@@ -261,6 +265,7 @@ export default class ContractManager {
             if(index > -1){
                 this.processing.splice(index, 1);
             }
+            this.addContractToCache(address, null);
             return;
         }
         this.addContractToCache(address, contract);

--- a/src/lib/transaction-utils.ts
+++ b/src/lib/transaction-utils.ts
@@ -176,7 +176,7 @@ export const getDirection = (address: string, row: NftTransferData) => {
     } else if (toChecksumAddress(address) === toChecksumAddress(row.to)) {
         return 'in';
     } else {
-        return 'unknown';
+        return 'to';
     }
 };
 

--- a/src/pages/AccountPage.vue
+++ b/src/pages/AccountPage.vue
@@ -62,8 +62,10 @@ watch(accountAddress, (newVal, oldVal) => {
 }, { deep: true, immediate: true });
 
 watch(() => route.query.tab, (newTab) => {
-    const str = newTab as string;
-    tab.value = tabs.includes(str) ? str : tabs[0];
+    if (route.name === 'address') {
+        const str = newTab as string;
+        tab.value = tabs.includes(str) ? str : tabs[0];
+    }
 });
 
 watch(tab, (newTab) => {
@@ -313,8 +315,7 @@ async function loadAccount() {
             </q-tab-panel>
             <q-tab-panel v-else name="internaltx">
                 <InternalTransactionFlatTable
-                    :title="accountAddress"
-                    :filter="{address:accountAddress}"
+                    :address="accountAddress"
                     :usePagination="false"
                 />
             </q-tab-panel>

--- a/src/pages/InternalTrxPage.vue
+++ b/src/pages/InternalTrxPage.vue
@@ -1,137 +1,15 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
-import { useStore } from 'vuex';
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
-import { contractManager } from 'src/boot/telosApi';
-import { indexerApi } from 'src/boot/telosApi';
-import { evm } from 'src/boot/evm';
-import { toChecksumAddress } from 'src/lib/utils';
-import { getIcon } from 'src/lib/token-utils';
-import Contract from 'src/lib/contract/Contract';
-import { BalanceQueryResponse, BalanceResult } from 'src/types/BalanceResult';
-import { Token } from 'src/types/Token';
 
-import TransactionTable from 'components/TransactionTable.vue';
+
 import InternalTransactionFlatTable from 'components/InternalTransactionFlatTable.vue';
-import NftTransfersTable from 'components/NftTransfersTable.vue';
-import TokenList from 'components/Token/TokenList.vue';
-import ApprovalList from 'components/Token/ApprovalList.vue';
-import HolderList from 'components/Token/HolderList.vue';
-import NFTList from 'components/Token/NFTList.vue';
-import ContractTab from 'components/ContractTab/ContractTab.vue';
-import CopyButton from 'components/CopyButton.vue';
-import GenericContractInterface from 'components/ContractTab/GenericContractInterface.vue';
-import AddressQR from 'src/components/AddressQR.vue';
-import AddressOverview from 'src/components/AddressOverview.vue';
-import AddressMoreInfo from 'src/components/AddressMoreInfo.vue';
-import ContractMoreInfo from 'src/components/ContractMoreInfo.vue';
-
+import AddressField from 'components/AddressField.vue';
 
 const { t: $t } = useI18n();
 const route = useRoute();
-const router = useRouter();
-const store = useStore();
-
-const loading = ref(false);
-const title = ref('');
-const fullTitle = ref('');
-const telosAccount = ref('');
-const balance = ref('0');
-const nonce = ref<number | null>(null);
-const contract = ref<Contract | null>(null);
-const tab = ref(tabs[0]);
-const initialLoadComplete = ref(false);
-
-const accountAddress = computed(() => route.params.address as string ?? '');
-const isLoggedIn = computed(() => store.getters['login/isLoggedIn']);
-const address = computed(() => store.getters['login/address']);
-
-watch(accountAddress, (newVal, oldVal) => {
-    if (newVal !== oldVal) {
-        const newAsChecksum = toChecksumAddress(newVal);
-        if (newAsChecksum !== newVal) {
-            router.replace({ params: { address: newAsChecksum } });
-        }
-        loadAccount().then(() => {
-            initialLoadComplete.value = true;
-        });
-    }
-}, { deep: true, immediate: true });
-
-watch(() => route.query.tab, (newTab) => {
-    const str = newTab as string;
-    tab.value = tabs.includes(str) ? str : tabs[0];
-});
-
-watch(tab, (newTab) => {
-    router.push({ query: { tab: newTab } });
-});
-
-watch(isLoggedIn, (value) => {
-    // if user logs out while on approvals tab return to transactions
-    if (!value && tab.value === 'approvals'){
-        router.push({ query: { tab: 'transactions' } });
-    }
-});
-
-onMounted(() => {
-    const tabQueryParam = route.query.tab as string;
-    tab.value = tabs.includes(tabQueryParam) ? tabQueryParam : tabs[0];
-});
-
-async function loadAccount() {
-    if(!accountAddress.value || accountLoading.value){
-        return;
-    }
-    accountLoading.value = true;
-    const tokenList = await contractManager.getTokenList();
-    try {
-        const response: BalanceQueryResponse = await indexerApi.get(
-            `/account/${accountAddress.value}/balances?includeAbi=true`,
-            // `/account/${accountAddress.value}/balances?contract=___NATIVE_CURRENCY___&includeAbi=true`,
-        );
-        //TODO restore original api query when contract param query is fixed
-        const systemTokenResult = response.data.results.find((r : BalanceResult) => r.contract === '___NATIVE_CURRENCY___') as BalanceResult;
-
-        // balance.value = (response.data?.results?.length > 0) ? response.data.results[0].balance : '0';
-        balance.value = systemTokenResult ? systemTokenResult.balance : '0';
-    } catch (e) {
-        console.error('Could not get balance: ', e);
-    }
-    contract.value = null;
-    fullTitle.value = '';
-    nonce.value = 0;
-    title.value = $t('pages.account');
-    const force = true;
-    const cachedContract = await contractManager.getContract(accountAddress.value, force);
-    if (cachedContract?.creationInfo?.transaction || cachedContract?.supportedInterfaces?.length > 0){
-        contract.value = cachedContract;
-        if(contract.value && contract.value.supportedInterfaces?.includes('erc20')){
-            tokenList.tokens.forEach((token: Token) => {
-                if(token.address.toLowerCase() ===  contract.value?.address.toLowerCase()){
-                    contract.value.issuer = token.issuer;
-                    contract.value.issuer_link = token.issuer_link;
-                    contract.value.logoURI = token.logoURI;
-                    contract.value.setVerified(true);
-                }
-            });
-        }
-        title.value = $t('pages.contract');
-    } else {
-        contractManager.addContractToCache(accountAddress.value, { address: accountAddress.value });
-        try {
-            const account = await evm.telos.getEthAccount(accountAddress.value);
-            telosAccount.value = account?.account;
-            nonce.value = account?.nonce;
-        } catch (e) {
-            console.info(e);
-        }
-    }
-
-    accountLoading.value = false;
-    fullTitle.value = contract.value?.getName() ?? '';
-}
+const address = computed(() => route.query.a as string);
 
 </script>
 
@@ -139,21 +17,20 @@ async function loadAccount() {
 <q-page class="c-internal-trx">
 
     <div class="c-internal-trx__header">
-        <span class="c-internal-trx__header-title">{{ $t('pages.internaltrx.page_title') }}</span>
-        <span class="c-internal-trx__header-sub-title">{{ $t('pages.internaltrx.for_address', { address: address }) }}</span>
+        <div class="c-internal-trx__header-title">{{ $t('pages.internaltrx.page_title') }}</div>
+        <div class="c-internal-trx__header-sub-title">{{ $t('pages.internaltrx.for_address') }}
+            <AddressField
+                :address="address"
+            />
+        </div>
     </div>
 
     <div class="c-internal-trx__body">
         <q-card>
-            <q-toggle
-                v-model="showEmptyBlocks"
-                class="c-internal-trx__toggle"
-                label="display empty blocks"
-                color="primary"
-                checked-icon="visibility"
-                unchecked-icon="visibility_off"
+            <InternalTransactionFlatTable
+                :address="address"
+                :usePagination="true"
             />
-            <BlockTable :showEmptyBlocks='showEmptyBlocks' class="c-internal-trx__block-table" :title="'Block List'"/>
         </q-card>
     </div>
 
@@ -167,25 +44,10 @@ async function loadAccount() {
 
     &__header {
         @include page-header;
-    }
 
-    &__tabs {
-        @include tabs-container;
-    }
-
-    &__main-container {
-        background: transparent !important;
-    }
-    &__main-content {
-        padding: 0px;
-    }
-    &__panels {
-        background: transparent;
-        --v-overflow: visible;
-        overflow: visible !important;
-    }
-    &__panel {
-        padding: 0px;
+        &-sub-title {
+            --q-primary: var(--text-color);
+        }
     }
 }
 

--- a/src/pages/InternalTrxPage.vue
+++ b/src/pages/InternalTrxPage.vue
@@ -18,7 +18,7 @@ const address = computed(() => route.query.a as string);
 
     <div class="c-internal-trx__header">
         <div class="c-internal-trx__header-title">{{ $t('pages.internaltrx.page_title') }}</div>
-        <div class="c-internal-trx__header-sub-title">{{ $t('pages.internaltrx.for_address') }}
+        <div v-if="address" class="c-internal-trx__header-sub-title">{{ $t('pages.internaltrx.for_address') }}
             <AddressField
                 :address="address"
             />

--- a/src/pages/InternalTrxPage.vue
+++ b/src/pages/InternalTrxPage.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useStore } from 'vuex';
+import { useI18n } from 'vue-i18n';
+import { contractManager } from 'src/boot/telosApi';
+import { indexerApi } from 'src/boot/telosApi';
+import { evm } from 'src/boot/evm';
+import { toChecksumAddress } from 'src/lib/utils';
+import { getIcon } from 'src/lib/token-utils';
+import Contract from 'src/lib/contract/Contract';
+import { BalanceQueryResponse, BalanceResult } from 'src/types/BalanceResult';
+import { Token } from 'src/types/Token';
+
+import TransactionTable from 'components/TransactionTable.vue';
+import InternalTransactionFlatTable from 'components/InternalTransactionFlatTable.vue';
+import NftTransfersTable from 'components/NftTransfersTable.vue';
+import TokenList from 'components/Token/TokenList.vue';
+import ApprovalList from 'components/Token/ApprovalList.vue';
+import HolderList from 'components/Token/HolderList.vue';
+import NFTList from 'components/Token/NFTList.vue';
+import ContractTab from 'components/ContractTab/ContractTab.vue';
+import CopyButton from 'components/CopyButton.vue';
+import GenericContractInterface from 'components/ContractTab/GenericContractInterface.vue';
+import AddressQR from 'src/components/AddressQR.vue';
+import AddressOverview from 'src/components/AddressOverview.vue';
+import AddressMoreInfo from 'src/components/AddressMoreInfo.vue';
+import ContractMoreInfo from 'src/components/ContractMoreInfo.vue';
+
+
+const { t: $t } = useI18n();
+const route = useRoute();
+const router = useRouter();
+const store = useStore();
+
+const loading = ref(false);
+const title = ref('');
+const fullTitle = ref('');
+const telosAccount = ref('');
+const balance = ref('0');
+const nonce = ref<number | null>(null);
+const contract = ref<Contract | null>(null);
+const tab = ref(tabs[0]);
+const initialLoadComplete = ref(false);
+
+const accountAddress = computed(() => route.params.address as string ?? '');
+const isLoggedIn = computed(() => store.getters['login/isLoggedIn']);
+const address = computed(() => store.getters['login/address']);
+
+watch(accountAddress, (newVal, oldVal) => {
+    if (newVal !== oldVal) {
+        const newAsChecksum = toChecksumAddress(newVal);
+        if (newAsChecksum !== newVal) {
+            router.replace({ params: { address: newAsChecksum } });
+        }
+        loadAccount().then(() => {
+            initialLoadComplete.value = true;
+        });
+    }
+}, { deep: true, immediate: true });
+
+watch(() => route.query.tab, (newTab) => {
+    const str = newTab as string;
+    tab.value = tabs.includes(str) ? str : tabs[0];
+});
+
+watch(tab, (newTab) => {
+    router.push({ query: { tab: newTab } });
+});
+
+watch(isLoggedIn, (value) => {
+    // if user logs out while on approvals tab return to transactions
+    if (!value && tab.value === 'approvals'){
+        router.push({ query: { tab: 'transactions' } });
+    }
+});
+
+onMounted(() => {
+    const tabQueryParam = route.query.tab as string;
+    tab.value = tabs.includes(tabQueryParam) ? tabQueryParam : tabs[0];
+});
+
+async function loadAccount() {
+    if(!accountAddress.value || accountLoading.value){
+        return;
+    }
+    accountLoading.value = true;
+    const tokenList = await contractManager.getTokenList();
+    try {
+        const response: BalanceQueryResponse = await indexerApi.get(
+            `/account/${accountAddress.value}/balances?includeAbi=true`,
+            // `/account/${accountAddress.value}/balances?contract=___NATIVE_CURRENCY___&includeAbi=true`,
+        );
+        //TODO restore original api query when contract param query is fixed
+        const systemTokenResult = response.data.results.find((r : BalanceResult) => r.contract === '___NATIVE_CURRENCY___') as BalanceResult;
+
+        // balance.value = (response.data?.results?.length > 0) ? response.data.results[0].balance : '0';
+        balance.value = systemTokenResult ? systemTokenResult.balance : '0';
+    } catch (e) {
+        console.error('Could not get balance: ', e);
+    }
+    contract.value = null;
+    fullTitle.value = '';
+    nonce.value = 0;
+    title.value = $t('pages.account');
+    const force = true;
+    const cachedContract = await contractManager.getContract(accountAddress.value, force);
+    if (cachedContract?.creationInfo?.transaction || cachedContract?.supportedInterfaces?.length > 0){
+        contract.value = cachedContract;
+        if(contract.value && contract.value.supportedInterfaces?.includes('erc20')){
+            tokenList.tokens.forEach((token: Token) => {
+                if(token.address.toLowerCase() ===  contract.value?.address.toLowerCase()){
+                    contract.value.issuer = token.issuer;
+                    contract.value.issuer_link = token.issuer_link;
+                    contract.value.logoURI = token.logoURI;
+                    contract.value.setVerified(true);
+                }
+            });
+        }
+        title.value = $t('pages.contract');
+    } else {
+        contractManager.addContractToCache(accountAddress.value, { address: accountAddress.value });
+        try {
+            const account = await evm.telos.getEthAccount(accountAddress.value);
+            telosAccount.value = account?.account;
+            nonce.value = account?.nonce;
+        } catch (e) {
+            console.info(e);
+        }
+    }
+
+    accountLoading.value = false;
+    fullTitle.value = contract.value?.getName() ?? '';
+}
+
+</script>
+
+<template>
+<q-page class="c-internal-trx">
+
+    <div class="c-internal-trx__header">
+        <span class="c-internal-trx__header-title">{{ $t('pages.internaltrx.page_title') }}</span>
+        <span class="c-internal-trx__header-sub-title">{{ $t('pages.internaltrx.for_address', { address: address }) }}</span>
+    </div>
+
+    <div class="c-internal-trx__body">
+        <q-card>
+            <q-toggle
+                v-model="showEmptyBlocks"
+                class="c-internal-trx__toggle"
+                label="display empty blocks"
+                color="primary"
+                checked-icon="visibility"
+                unchecked-icon="visibility_off"
+            />
+            <BlockTable :showEmptyBlocks='showEmptyBlocks' class="c-internal-trx__block-table" :title="'Block List'"/>
+        </q-card>
+    </div>
+
+</q-page>
+</template>
+
+<style lang="scss">
+
+.c-internal-trx {
+    @include page-container;
+
+    &__header {
+        @include page-header;
+    }
+
+    &__tabs {
+        @include tabs-container;
+    }
+
+    &__main-container {
+        background: transparent !important;
+    }
+    &__main-content {
+        padding: 0px;
+    }
+    &__panels {
+        background: transparent;
+        --v-overflow: visible;
+        overflow: visible !important;
+    }
+    &__panel {
+        padding: 0px;
+    }
+}
+
+</style>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -105,12 +105,12 @@ const routes = [
         }],
     },
     {
-        path: '/txsInternal',
+        path: '/txsinternal',
         component: () => import('layouts/MainLayout.vue'),
         children: [{
             path: '',
-            name: 'txsInternal',
-            component: () => import('pages/ErrorNotFoundPage.vue'),
+            name: 'txsinternal',
+            component: () => import('pages/InternalTrxPage.vue'),
         }],
     },
     {


### PR DESCRIPTION
# Fixes #567

## Description
This PR continues the work on this [other PR](https://github.com/telosnetwork/teloscan/pull/723) and adds a specific page to display a paginated table of internal transactions for the given address. It is possible to expand and collapse all internal transactions as in the previous implementation, but this information is shown in a flat mode in this new component.

## Test scenarios
- https://deploy-preview-731--dev-mainnet-teloscan.netlify.app/txsinternal?a=0x8a8AFe1A74a1cc8babD78c8eB138aF589123adD2
![image](https://github.com/telosnetwork/teloscan/assets/4420760/57a20bae-9e31-495f-ba99-dec55c0aa0bf)

- https://deploy-preview-731--dev-mainnet-teloscan.netlify.app/txsinternal 
![image](https://github.com/telosnetwork/teloscan/assets/4420760/c8c868a4-a0ad-4379-bf8d-fde05dcde9c6)



