### PR TITLE
#722 | fix labels when overflow

### DIFF
--- a/src/components/ContractTab/ContractInterface.vue
+++ b/src/components/ContractTab/ContractInterface.vue
@@ -43,7 +43,7 @@ onMounted(async () => {
 </script>
 
 <template>
-<div class="q-pt-md">
+<div class="c-contract-interface q-pt-md">
     <AppHeaderWallet v-if="props.write" class="c-login-button c-contract-interface__login"/>
     <q-list class="c-contract-interface__container">
         <q-expansion-item
@@ -81,6 +81,13 @@ onMounted(async () => {
         margin-bottom: 0.75rem !important;
         margin-left: 1rem;
     }
+
+    .q-item__label {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 }
+
 
 </style>


### PR DESCRIPTION
# Fixes #722 

## Description
This PR forces the labels to use ellipsis when the space is not wide enough.

## Test scenarios
- https://deploy-preview-743--dev-mainnet-teloscan.netlify.app/address/0x7138B62539C410E14E6471c22EC739F6A6985E58?tab=contract 
![image](https://github.com/telosnetwork/teloscan/assets/4420760/07900a84-7827-4979-b2f8-2e11df95af41)
