### PR TITLE
#606 | transaction pagination based on key

### DIFF
--- a/src/components/TransactionTable.vue
+++ b/src/components/TransactionTable.vue
@@ -18,7 +18,7 @@ import TransactionDialog from 'components/TransactionDialog.vue';
 import TransactionField from 'components/TransactionField.vue';
 import TransactionFeeField from 'components/TransactionFeeField.vue';
 
-import { Pagination } from 'src/types';
+import { Pagination, PaginationByKey } from 'src/types';
 import { useStore } from 'vuex';
 
 const $q = useQuasar();
@@ -41,7 +41,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
     title: '',
-    initialPageSize: 1,
+    initialPageSize: 50,
     accountAddress: '',
 });
 
@@ -56,13 +56,14 @@ const totalRows = ref(0);
 const transactions: any[] = [];
 const page_size_options = [10, 25, 50, 100];
 
-const pagination = ref<Pagination>(
+const pagination = ref<PaginationByKey>(
     {
-        sortBy: 'block',
+        key: 0,
+        page: 0,
         descending: true,
-        page: 1,
-        rowsPerPage: 50,
+        rowsPerPage: props.initialPageSize,
         rowsNumber: 0,
+        initialKey: 0,
     },
 );
 
@@ -136,9 +137,10 @@ function updateColumns() {
 
 watch(() => route.query,
     (query) => {
+        // key=1232322&rowsPerPage=50&sort=DESC
         const { p, rowsPerPage, sort } = query;
 
-        let page = p ? Number(p) : 1;
+        let page = p ? Number(p) : 0;
         let size = rowsPerPage ? Number(rowsPerPage) : pagination.value.rowsPerPage;
         let desc = sort ? sort === 'DESC' : true;
 
@@ -148,13 +150,17 @@ watch(() => route.query,
 );
 
 function setPagination(page: number, size: number, desc: boolean) {
-    if (page) {
-        pagination.value.page = page;
-    }
-    if (size) {
-        pagination.value.rowsPerPage = size;
-    }
+    console.log('setPagination()', { page, size, desc, initialKey: pagination.value.initialKey });
+    pagination.value.page = page;
+    pagination.value.rowsPerPage = size;
     pagination.value.descending = desc;
+
+    if (pagination.value.initialKey > 0) {
+        // key is page pages away from the initial key
+        const zero_base_page = page - 1;
+        pagination.value.key = pagination.value.initialKey - (zero_base_page * pagination.value.rowsPerPage);
+        console.log('setPagination() key ->', pagination.value.key);
+    }
     updateColumns();
     parseTransactions();
 }
@@ -180,22 +186,26 @@ async function parseTransactions() {
         return;
     }
     loading.value = true;
-    const { page, rowsPerPage, sortBy, descending } = pagination.value;
+    const { key, rowsPerPage, descending } = pagination.value;
 
 
     try {
-        let response = await indexerApi.get(getPath());
+        const path = await getPath();
+        let response = await indexerApi.get(path);
         totalRows.value = response.data?.total_count;
-        const results = response.data.results.slice(0, FIVE_HUNDRED_K);
+        const results = response.data.results;
+        const next = response.data.next;
 
-        if (pagination.value.rowsNumber === 0) {
-            pagination.value.rowsNumber = response.data?.total_count > FIVE_HUNDRED_K ? FIVE_HUNDRED_K : response.data?.total_count;
+        if (pagination.value.initialKey === 0) {
+            pagination.value.initialKey = next + rowsPerPage;
         }
 
-        pagination.value.page = page;
+        pagination.value.key = key === 0 ? next : key;
         pagination.value.rowsPerPage = rowsPerPage;
-        pagination.value.sortBy = sortBy;
         pagination.value.descending = descending;
+        if (pagination.value.rowsNumber === 0) {
+            pagination.value.rowsNumber = totalRows.value;
+        }
 
         transactions.splice(
             0,
@@ -270,21 +280,39 @@ function addEmptyToCache(contracts: any, transaction: any){
     }
 }
 
-function getPath() {
-    const { page, rowsPerPage, descending } = pagination.value;
+async function getPath() {
+    const { page, key, rowsPerPage, descending } = pagination.value;
     const prepend = props.accountAddress ? `address/${props.accountAddress}` : '';
     let path = `${prepend}/transactions?limit=${
-        rowsPerPage === 0 ? 500 : rowsPerPage
+        rowsPerPage === 0 ? 100 : Math.min(rowsPerPage, props.initialPageSize)
     }`;
-    path += `&offset=${(page - 1) * rowsPerPage}`;
-    path += `&sort=${descending ? 'desc' : 'asc'}`;
-    path += (pagination.value.rowsNumber === 0) ? '&includePagination=true' : '';  // We only need the count once
-    if (props.block) {
-        if (props.accountAddress) {
-            path += `&startBlock=${props.block}&endBlock=${props.block}`;
-        } else {
-            path += `&block=${props.block}`;
+    if (props.accountAddress) {
+        path += `&offset=${(page - 1) * rowsPerPage}`;
+        path += `&sort=${descending ? 'desc' : 'asc'}`;
+        path += (pagination.value.rowsNumber === 0) ? '&includePagination=true' : '';  // We only need the count once
+        if (props.block) {
+            if (props.accountAddress) {
+                path += `&startBlock=${props.block}&endBlock=${props.block}`;
+            } else {
+                path += `&block=${props.block}`;
+            }
         }
+    } else {
+        if (pagination.value.initialKey === 0) {
+            // in the case of the first query, we need to get the initial key
+            let _aux_path = path.replace(/limit=\d+/, 'limit=1');
+            _aux_path += `&sort=${descending ? 'desc' : 'asc'}`;
+            _aux_path += '&includePagination=true';
+            _aux_path += '&key=0';
+            let response = await indexerApi.get(_aux_path);
+            const next = response.data.next;
+            pagination.value.initialKey = next + 1;
+            console.log('--->', { next, initialKey: pagination.value.initialKey });
+        }
+        path += `&sort=${descending ? 'desc' : 'asc'}`;
+        path += '&includePagination=true';
+        path += '&includeAbi=true';
+        path += `&key=${key}`;
     }
     return path;
 }

--- a/src/types/Pagination.ts
+++ b/src/types/Pagination.ts
@@ -5,3 +5,13 @@ export type Pagination = {
     rowsPerPage: number;
     rowsNumber: number;
 }
+
+
+export type PaginationByKey = {
+    page: number;
+    key: number;
+    initialKey: number;
+    descending: boolean;
+    rowsPerPage: number;
+    rowsNumber: number;
+}


### PR DESCRIPTION
# Fixes #606

## Description
This PR modifies the way we paginate content on the transaction page. Now we use the `key `parameter when before we were using _offset_ parameter.

## Test scenarios
- Go to [this page](https://deploy-preview-744--dev-mainnet-teloscan.netlify.app/txs?p=1&rowsPerPage=10&sort=DESC)
- open dev tools (F12) and go to Network
- filter by text: "transactions"
  - you should see a first call using key=0 and limit=1
  - you should see a second normal call using the correct limit
- go to next page
  - you should not see a query with key=0 this time
  - you should see a query using the previous "next" parameter

- Go to the [first page](https://deploy-preview-744--dev-mainnet-teloscan.netlify.app/txs?p=1&rowsPerPage=10&sort=DESC) again
- wait 5 min and refresh the page
  - you should see no changes
- keep this tap open (let's call it Freezed-Tap)
- open a new [tab with a fresh key](https://deploy-preview-744--dev-mainnet-teloscan.netlify.app/txs)
- refresh until a new transaction appears
- now come back to the Freezed-Tap left opened and refresh the page
  - you should keep seeing the same transaction page (with no new transactions)
