### PR TITLE
#715 | fix Metamask popup problem

### DIFF
--- a/src/antelope/mocks/AccountStore.ts
+++ b/src/antelope/mocks/AccountStore.ts
@@ -54,11 +54,15 @@ class AccountStore {
 
     async loginEVM({ authenticator, network, autoLogAccount }: LoginEVMActionData, trackAnalyticsEvents: boolean): Promise<boolean> {
         currentAuthenticator = authenticator;
-        currentAccount = autoLogAccount ? await authenticator.autoLogin(network, autoLogAccount, trackAnalyticsEvents) : await authenticator.login(network, trackAnalyticsEvents);
+        currentAccount = autoLogAccount
+            ? await authenticator.autoLogin(network, autoLogAccount, trackAnalyticsEvents)
+            : await authenticator.login(network, trackAnalyticsEvents);
 
-        const account = useAccountStore().getAccount(authenticator.label);
-        getAntelope().events.onLoggedIn.next(account);
-        return true;
+        if (currentAccount) {
+            const account = useAccountStore().getAccount(authenticator.label);
+            getAntelope().events.onLoggedIn.next(account);
+        }
+        return !!currentAccount;
     }
 
     logout() {

--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -154,15 +154,7 @@ async function loginWithAntelope(name:string, autoLogAccount?: string) {
     }
     const authenticator = auth.newInstance(label);
     const network = useChainStore().currentChain.settings.getNetwork();
-    useAccountStore().loginEVM({ authenticator, network, autoLogAccount }, true).then(() => {
-        const address = useAccountStore().getAccount(label).account;
-        setLogin({ address });
-        localStorage.setItem(LOGIN_DATA_KEY, JSON.stringify({
-            type: LOGIN_EVM,
-            provider: name,
-            account: address,
-        }));
-    });
+    useAccountStore().loginEVM({ authenticator, network, autoLogAccount }, true);
     emit('hide');
 }
 

--- a/src/components/TransactionTable.vue
+++ b/src/components/TransactionTable.vue
@@ -150,7 +150,6 @@ watch(() => route.query,
 );
 
 function setPagination(page: number, size: number, desc: boolean) {
-    console.log('setPagination()', { page, size, desc, initialKey: pagination.value.initialKey });
     pagination.value.page = page;
     pagination.value.rowsPerPage = size;
     pagination.value.descending = desc;
@@ -159,7 +158,6 @@ function setPagination(page: number, size: number, desc: boolean) {
         // key is page pages away from the initial key
         const zero_base_page = page - 1;
         pagination.value.key = pagination.value.initialKey - (zero_base_page * pagination.value.rowsPerPage);
-        console.log('setPagination() key ->', pagination.value.key);
     }
     updateColumns();
     parseTransactions();


### PR DESCRIPTION
# Fixes #715

## Description
In the previous version, after a not finished attempt to login using Metamask, the user experimented a constant and annoying behavior of the Metamask poping up each time the page gets refreshed.
This PR fixes this problem.

## Test scenarios
- If you have your Metamask open, change the Network to Ethereum. If not, just let it close.
- Go to [this url](https://deploy-preview-750--dev-mainnet-teloscan.netlify.app/)
- press "Connect Wallet"
- Select Metamask but refuse to connect (cancel the process).
  - the website should return to normal disconnected state
- refresh the page (F5)
  - Metamask should not popup to ask you to login.
