### PR TITLE
bugfix - avoid using null contract

### DIFF
--- a/src/lib/contract/ContractManager.js
+++ b/src/lib/contract/ContractManager.js
@@ -51,7 +51,7 @@ export default class ContractManager {
         return transfers;
     }
     async parseContractTransaction(raw, data, contract, transfers) {
-        if (data === '0x' || data === null || !contract) {
+        if (data === '0x' || !data || !contract) {
             return false;
         }
         if (contract.getInterface()) {

--- a/src/lib/contract/ContractManager.js
+++ b/src/lib/contract/ContractManager.js
@@ -51,7 +51,7 @@ export default class ContractManager {
         return transfers;
     }
     async parseContractTransaction(raw, data, contract, transfers) {
-        if (data === '0x' || data === null || typeof contract === 'undefined') {
+        if (data === '0x' || data === null || !contract) {
             return false;
         }
         if (contract.getInterface()) {


### PR DESCRIPTION
# Fixes #755

## Description
There was a variable being used before checking if it was null. That is checked now which avoids the bug.

## Test scenarios
go to https://deploy-preview-756--testnet-teloscan.netlify.app/tx/0x4c072f0cf146c23e69d722876ace7181847fb07c36d81a72329c3f49bef7030e

![image](https://github.com/telosnetwork/teloscan/assets/4420760/afd7db91-5535-41ac-9fbc-588a3aa8823e)

