### PR TITLE
#740 | Popup Image viewer for NFTs

### DIFF
--- a/src/components/ImagePopup.vue
+++ b/src/components/ImagePopup.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+// Props interface
+interface Props {
+    title: string;
+    image: string;
+    previewSize: number
+}
+
+const props = defineProps<Props>();
+const { t: $t } = useI18n();
+
+// Reactive variables
+const isPopupVisible = ref(false);
+const isExpanded = ref(false);
+
+// Methods
+const togglePopup = () => {
+    isPopupVisible.value = !isPopupVisible.value;
+};
+
+const toggleExpand = () => {
+    isExpanded.value = !isExpanded.value;
+};
+
+const downloadImage = () => {
+    const link = document.createElement('a');
+    link.href = props.image;
+    link.download = 'downloaded-image';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+};
+
+const previousScrollY = ref(0);
+watch(isPopupVisible, (value) => {
+    // This is a workaround very related to the issue with the dialog not scrolling to the top
+    // https://github.com/telosnetwork/teloscan/issues/625
+    if (value) {
+        previousScrollY.value = window.scrollY;
+    } else {
+        // what for the scroll and if it moves, correct it and end
+        const timer = setInterval(() => {
+            if (window.scrollY > 0) {
+                window.scrollTo({ top: previousScrollY.value, behavior: 'instant' });
+                clearInterval(timer);
+            }
+        }, 0);
+        // avoid the interval to run forever
+        setTimeout(() => {
+            window.scrollTo({ top: previousScrollY.value, behavior: 'instant' });
+            clearInterval(timer);
+        }, 100);
+    }
+});
+
+watch(() => props.previewSize, () => {
+    console.log('props.previewSize', props.previewSize);
+});
+
+</script>
+
+<template>
+<div class="c-image-viewer">
+    <img
+        :src="props.image"
+        :width="props.previewSize"
+        class="c-image-viewer__thumbnail"
+        alt="thumbnail"
+        @click="togglePopup"
+    >
+    <q-dialog v-model="isPopupVisible">
+        <q-card
+            :class="{
+                'c-image-viewer__popup': true,
+                'c-image-viewer__popup--expanded': isExpanded
+            }"
+        >
+            <q-card-section class="c-image-viewer__header">
+                <div>{{ props.title }}</div>
+                <div>
+                    <q-btn
+                        flat
+                        dense
+                        :icon="isExpanded ? 'crop_original': 'crop_free'"
+                        :class="{'c-image-viewer__header-btn--selected': isExpanded}"
+                        @click="toggleExpand"
+                    >
+                        <q-tooltip>{{ $t('components.toggle_expand') }}</q-tooltip>
+                    </q-btn>
+                    <q-btn
+                        flat
+                        dense
+                        icon="file_download"
+                        @click="downloadImage"
+                    >
+                        <q-tooltip>{{ $t('components.download_image') }}</q-tooltip>
+                    </q-btn>
+                    <q-btn
+                        flat
+                        dense
+                        icon="close"
+                        @click="togglePopup"
+                    >
+                        <q-tooltip>{{ $t('components.close') }}</q-tooltip>
+                    </q-btn>
+                </div>
+            </q-card-section>
+            <q-card-section class="c-image-viewer__body" @click="toggleExpand">
+                <div
+                    v-if="isExpanded"
+                    :style="{ backgroundImage: `url(${props.image})` }"
+                    class="c-image-viewer__image c-image-viewer__image--embeded"
+                    alt="full size"
+                ></div>
+                <img
+                    v-else
+                    :src="props.image"
+                    :class="{
+                        'c-image-viewer__image': true,
+                    }"
+                    alt="full size"
+                >
+            </q-card-section>
+        </q-card>
+    </q-dialog>
+</div>
+</template>
+
+<style lang="scss">
+.c-image-viewer {
+    &__thumbnail {
+        cursor: pointer;
+    }
+
+    &__popup {
+        --full-width: auto;
+        --full-height: auto;
+        width: var(--full-width);
+        height: var(--full-height);
+        &--expanded {
+            --full-width: 98vw;
+            --full-height: 98vh;
+        }
+        background-color: var(--bg-color);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        max-width: none !important;
+    }
+
+    &__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background-color: var(--header-bg-color);
+        padding: 0.5rem;
+        color: var(--text-color);
+
+        &-btn--selected {
+            background-color: var(--btn-s-bg-color);
+            color: var(--btn-s-color);
+        }
+    }
+
+    &__body {
+        flex-grow: 1;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        overflow: auto;
+    }
+
+    &__image {
+        max-width: 100%;
+        max-height: 100%;
+    }
+
+    &__image--embeded {
+        background-size: contain;
+        background-position: center;
+        background-repeat: no-repeat;
+        width: 100%;
+        height: 100%;
+    }
+
+    &__image--original {
+        max-width: none;
+        max-height: none;
+    }
+}
+</style>

--- a/src/components/Token/NFTList.vue
+++ b/src/components/Token/NFTList.vue
@@ -9,13 +9,14 @@ import AddressField from 'components/AddressField.vue';
 import BlockField from 'components/BlockField.vue';
 import ImagePopup from 'src/components/ImagePopup.vue';
 import { NFT, NFT_TYPE } from 'src/types/NFT';
-import { QTableProps } from 'quasar';
+import { QTableProps, useQuasar } from 'quasar';
 
 
 
 const allowedFilters = ['contract', 'account'];
 
 const { t : $t } = useI18n();
+const $q = useQuasar();
 
 const props = defineProps({
     address: {
@@ -348,7 +349,7 @@ onMounted(() => {
                             :previewSize="previewSize"
                         />
                     </span>
-                    <q-tooltip v-if="props.row?.metadata?.description">{{ props.row.metadata.description }}</q-tooltip>
+                    <q-tooltip v-if="props.row?.metadata?.description && $q.screen.gt.md">{{ props.row.metadata.description }}</q-tooltip>
                 </q-td>
                 <q-td key="metadata" :props="props">
                     <a

--- a/src/components/Token/NFTList.vue
+++ b/src/components/Token/NFTList.vue
@@ -3,11 +3,11 @@
 import { ref, watch, onMounted, onBeforeMount } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { indexerApi } from 'src/boot/telosApi';
-import { notifyMessage, icons, NotificationAction } from 'src/boot/errorHandling';
 import { ALLOWED_VIDEO_EXTENSIONS } from 'src/lib/utils';
 
 import AddressField from 'components/AddressField.vue';
 import BlockField from 'components/BlockField.vue';
+import ImagePopup from 'src/components/ImagePopup.vue';
 import { NFT, NFT_TYPE } from 'src/types/NFT';
 import { QTableProps } from 'quasar';
 
@@ -158,12 +158,6 @@ function hasVideo(nft: NFT) {
     return nft;
 }
 
-function isDataImage(nft: NFT) {
-    let image = getMedia(nft);
-    const regex = new RegExp(/(data:image\/[^;]+;base64[^"]+)/);
-    return regex.test(image);
-}
-
 async function onRequest() {
     loading.value = true;
 
@@ -217,24 +211,20 @@ function getPath(type: string) {
     return `/${queryFilter}/${props.address}/nfts?type=${type}&includeAbi=true&limit=10000&forceMetadata=1&includePagination=true`;
 }
 
-function confirmDownloadImage(imageData: string, name: string) {
-    notifyMessage (
-        'success',
-        icons.info,
-        $t('components.download_image'),
-        $t('components.confirm_download_image'),
-        new NotificationAction({
-            label: $t('components.confirm'),
-            handler: () => {
-                // download image
-                const link = document.createElement('a');
-                link.href = imageData;
-                link.download = name;
-                link.click();
-            },
-        }),
-    );
-}
+// Media display
+const previewSize = ref(36);
+const toggleMediaSize = () => {
+    previewSize.value = (previewSize.value === 36) ? 72 : 36;
+    // save in storage
+    localStorage.setItem('mediaSize', previewSize.value.toString());
+};
+onMounted(() => {
+    const size = localStorage.getItem('mediaSize');
+    if(size){
+        previewSize.value = parseInt(size);
+    }
+});
+
 </script>
 
 <template>
@@ -256,7 +246,14 @@ function confirmDownloadImage(imageData: string, name: string) {
                     :key="col.name"
                     :props="props"
                 >
-                    <div class="u-flex--center-y">
+                    <div v-if="col.name==='media'" class="u-flex--center-y" @click="toggleMediaSize">
+                        <a>{{ col.label }}</a>
+                        <q-icon class="info-icon q-ml-xs" name="far fa-question-circle"/>
+                        <q-tooltip anchor="bottom middle" self="top middle">
+                            {{ $t('components.click_to_toggle_media_size') }}
+                        </q-tooltip>
+                    </div>
+                    <div v-else class="u-flex--center-y">
                         {{ col.label }}
                     </div>
                 </q-th>
@@ -342,33 +339,14 @@ function confirmDownloadImage(imageData: string, name: string) {
                         v-else-if="props.row.imageCache || props.row.metadata?.image"
                         clickable="clickable"
                     >
-                        <a
-                            v-if="props.row.imageCache && !isDataImage(props.row)"
-                            :href="
+                        <ImagePopup
+                            :image="
                                 (props.row.imageCache) ? props.row.imageCache + '/1440.webp' :
                                 props.row.metadata?.image
                             "
-                            target="_blank"
-                        >
-                            <q-img
-                                :src="props.row.imageCache + '/280.webp'"
-                                :alt="props.row.metadata?.name"
-                            />
-                        </a>
-                        <q-img
-                            v-else-if="isDataImage(props.row)"
-                            class="cursor-pointer"
-                            :src="props.row.metadata?.image"
-                            :alt="props.row.metadata?.name"
-                            @click="confirmDownloadImage(props.row.metadata?.image, props.row.metadata?.name)"
+                            :title="props.row.metadata?.name"
+                            :previewSize="previewSize"
                         />
-                        <a
-                            v-else
-                            :href="props.row.metadata?.image"
-                            target="_blank"
-                        >
-                            <q-img :src="props.row.metadata?.image" :alt="props.row.metadata?.name" />
-                        </a>
                     </span>
                     <q-tooltip v-if="props.row?.metadata?.description">{{ props.row.metadata.description }}</q-tooltip>
                 </q-td>

--- a/src/components/Token/NFTList.vue
+++ b/src/components/Token/NFTList.vue
@@ -250,7 +250,7 @@ onMounted(() => {
                     <div v-if="col.name==='media'" class="u-flex--center-y" @click="toggleMediaSize">
                         <a>{{ col.label }}</a>
                         <q-icon class="info-icon q-ml-xs" name="far fa-question-circle"/>
-                        <q-tooltip anchor="bottom middle" self="top middle">
+                        <q-tooltip v-it="$q.screen.gt.md" anchor="bottom middle" self="top middle">
                             {{ $t('components.click_to_toggle_media_size') }}
                         </q-tooltip>
                     </div>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -15,6 +15,8 @@ body {
 body.body--light {
     --border-color: #{$grey-3};
     --text-color: #{$dark};
+    --bg-color: white;
+    --header-bg-color: {$grey-3};
     --muted-text-color: #{$grey-3};
     --invert-text-color: white;
     --grey-text-color: #{$grey-7};
@@ -38,6 +40,8 @@ body.body--light {
 body.body--dark {
     --border-color: #{$grey-9};
     --text-color: white;
+    --bg-color: #181818;
+    --header-bg-color: #{$grey-10};
     --muted-text-color: #{$grey-8};
     --invert-text-color: #{$dark};
     --grey-text-color: #{$grey-5};

--- a/src/i18n/de-de/index.js
+++ b/src/i18n/de-de/index.js
@@ -274,6 +274,9 @@ export default {
         download_image: 'Bild herunterladen',
         confirm_download_image: 'Bestätigen Sie, dass Sie dieses Bild herunterladen möchten',
         confirm: 'Bestätigen',
+        click_to_toggle_media_size: 'Klicken, um die Mediengröße umzuschalten',
+        toggle_expand: 'Passform auf Bildschirm oder Originalgröße umschalten',
+        close: 'Schließen',
         transaction: {
             in: 'in',
             out: 'out',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -225,6 +225,9 @@ export default {
         download_image: 'Download Image',
         confirm_download_image: 'Confirm you want to download this image',
         confirm: 'Confirm',
+        click_to_toggle_media_size: 'Click to toggle media size',
+        toggle_expand: 'Toggle fit to screen of original size',
+        close: 'Close',
         approvals: {
             token_id: 'Token ID',
             approved: 'Approved',

--- a/src/i18n/es-es/index.js
+++ b/src/i18n/es-es/index.js
@@ -275,6 +275,9 @@ export default {
         download_image: 'Descargar imagen',
         confirm_download_image: 'Confirma que quieres descargar esta imagen',
         confirm: 'Confirmar',
+        click_to_toggle_media_size: 'Haga clic para cambiar el tamaño del medio',
+        toggle_expand: 'Alternar ajuste a pantalla o tamaño original',
+        close: 'Cerrar',
         transaction: {
             in: 'entra',
             out: 'sale',

--- a/src/i18n/fr-fr/index.js
+++ b/src/i18n/fr-fr/index.js
@@ -220,6 +220,9 @@ export default {
         download_image: 'Télécharger l’image',
         confirm_download_image: 'Confirmez que vous voulez télécharger cette image',
         confirm: 'Confirmer',
+        click_to_toggle_media_size: 'Cliquez pour changer la taille du média',
+        toggle_expand: 'Basculer pour s\'adapter à l\'écran ou taille originale',
+        close: 'Fermer',
         approvals: {
             token_id: 'ID Jeton',
             approved: 'Approuvé',

--- a/src/i18n/pt-br/index.js
+++ b/src/i18n/pt-br/index.js
@@ -274,6 +274,9 @@ export default {
         download_image: 'Baixar imagem',
         confirm_download_image: 'Confirme que deseja baixar esta imagem',
         confirm: 'Confirmar',
+        click_to_toggle_media_size: 'Clique para alternar o tamanho da mídia',
+        toggle_expand: 'Alternar ajuste à tela ou tamanho original',
+        close: 'Fechar',
         transaction: {
             in: 'in',
             out: 'out',


### PR DESCRIPTION
# Fixes #740

## Description
This PR adds a new component to preview the image in a popup dialog. This dialog can be resized and also includes a button to download the image.

## Test scenarios:
- https://deploy-preview-758--dev-mainnet-teloscan.netlify.app/address/0xe7209d65c5BB05Ddf799b20fF0EC09E691FC3f11?tab=nfts
In this link you can see tree cases in the same page:
- A normal size NFT:
![image](https://github.com/telosnetwork/teloscan/assets/4420760/fe5e5139-52dd-4a63-a258-96403647f05b)
- A really small one:
![image](https://github.com/telosnetwork/teloscan/assets/4420760/d20e2c6c-aa0c-493f-9037-9bcfaced95da)
- And a big image case:
![image](https://github.com/telosnetwork/teloscan/assets/4420760/88dda30f-eb48-48ee-9cbd-9df99076b254)


You can also change the image preview size on the table row by clicking the "Media"  title at the top of the column.
![image](https://github.com/telosnetwork/teloscan/assets/4420760/696f29c7-a218-4027-abf6-3bf1f6108a7b)
![image](https://github.com/telosnetwork/teloscan/assets/4420760/3b304ca3-90f0-448f-8d8e-fa32f9e3c543)




