### PR TITLE
#737 | workaround for the NaN age + fix false values not showing

### DIFF
--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -445,7 +445,7 @@ export default defineComponent({
     <p class="text-negative output-container">
         {{ errorMessage }}
     </p>
-    <div v-if="result" class="output-container">
+    <div v-if="result !== null" class="output-container">
         {{ $t('components.contract_tab.result') }} ({{ abi?.outputs.length > 0 ? abi.outputs[0].type : '' }}):
         <router-link v-if="abi?.outputs?.[0]?.type === 'address'" :to="`/address/${result}`" >{{ result }}</router-link>
         <template v-else>{{ result }}</template>

--- a/src/components/InternalTransactionFlatTable.vue
+++ b/src/components/InternalTransactionFlatTable.vue
@@ -210,6 +210,16 @@ export default {
             this.pagination.sortBy = sortBy;
             this.pagination.descending = descending;
             this.transactions = [...result.data.results];
+            this.transactions.forEach((transaction) => {
+                let timestamp = transaction.timestamp;
+                // This is a workaround to fix the timestamp issue (it should be fixed in the API)
+                // https://github.com/telosnetwork/teloscan-indexer/issues/234
+                if (typeof timestamp === 'string') {
+                    timestamp = new Date(timestamp).getTime() - new Date().getTimezoneOffset() * 60 * 1000;
+                    transaction.timestamp = timestamp;
+                }
+            });
+
             let totalTraces = 0;
             let processedTransactions = 0;
             for (const transaction of this.transactions) {


### PR DESCRIPTION
# Fixes #737, #760

This PR contains fixes for two issues.

## Description #737
This PR adds a workaround for the NaN age issue but should [be fixed on the backend](https://github.com/telosnetwork/teloscan-indexer/issues/234) since it can explode elsewhere.

## Description #760
This PR also adds a fix for the bug on the boolean queries not showing the false value. That is fixed and now it shows true and false values.

## Test scenarios #737
https://deploy-preview-764--dev-mainnet-teloscan.netlify.app/txsinternal
![image](https://github.com/telosnetwork/teloscan-indexer/assets/4420760/7cd50b9a-49ff-4a0a-a882-a37f39866a32)

## Test scenarios #760
https://deploy-preview-764--dev-mainnet-teloscan.netlify.app/address/0x75ab3C5bDd841BE0922a19139782f7650305dC05?tab=contract
- Go to Contract tab, press ABI from JSON, and insert this ABI into the input field:
```json
[
  {
    "inputs": [],
    "name": "isGood",
    "outputs": [
      {
        "internalType": "bool",
        "name": "",
        "type": "bool"
      }
    ],
    "stateMutability": "view",
    "type": "function"
  },
  {
    "inputs": [],
    "name": "setFalse",
    "outputs": [],
    "stateMutability": "nonpayable",
    "type": "function"
  },
  {
    "inputs": [],
    "name": "setTrue",
    "outputs": [],
    "stateMutability": "nonpayable",
    "type": "function"
  }
]
```
- Then read the isGood false value
![image](https://github.com/telosnetwork/teloscan/assets/4420760/858ec5cf-d2ec-4d92-ba4e-0da6f5a27eb8)
