### PR TITLE
#772 | No need to be logged to read from contracts

### DIFF
--- a/src/components/ContractTab/ContractInterface.vue
+++ b/src/components/ContractTab/ContractInterface.vue
@@ -59,6 +59,7 @@ onMounted(async () => {
                         :contract="props.contract"
                         :group="props.write ? 'write' : 'read'"
                         :run-label="props.write ? 'Write' : 'Query'"
+                        :write="props.write"
                     />
                 </div>
             </q-card>

--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -55,6 +55,10 @@ export default defineComponent({
             type: String,
             default: null,
         },
+        write: {
+            type: Boolean,
+            required: true,
+        },
     },
     data : () => {
         const decimalOptions = [{
@@ -211,7 +215,7 @@ export default defineComponent({
             this.showLoginModal = true;
         },
         async run() {
-            if (!this.isLoggedIn){
+            if (!this.isLoggedIn && this.write){
                 this.login();
                 return;
             }


### PR DESCRIPTION
# Fixes #772

## Description
This PR removes the need to be logged to execute the contract's read functions.

## Test scenarios
- Go to [this link](https://deploy-preview-773--teloscan-stage.netlify.app/token/0xa9991E4daA44922D00a78B6D986cDf628d46C4DD?tab=contract)
- make sure you are not logged
- Go to the Contract tab, then read tab
- try to read approvals with any pair of addresses.
  - you should be able to execute the function without being logged.