### PR TITLE
Add translations and column name for "Direction"

### DIFF
--- a/src/components/InternalTransactionFlatTable.vue
+++ b/src/components/InternalTransactionFlatTable.vue
@@ -119,6 +119,7 @@ export default {
         this.columns.filter(t => t.name === 'to')[0].label = this.$t('pages.to');
         this.columns.filter(t => t.name === 'value')[0].label = this.$t('pages.value');
         this.columns.filter(t => t.name === 'count')[0].label = this.$t('pages.count');
+        this.columns.filter(t => t.name === 'direction')[0].label = this.$t('components.direction');
         if (!this.usePagination) {
             this.pagination.rowsPerPage = 25;
             // we need to remove type and count columns

--- a/src/i18n/de-de/index.js
+++ b/src/i18n/de-de/index.js
@@ -243,6 +243,7 @@ export default {
         search_failed: 'Suche fehlgeschlagen, bitte geben Sie einen gültigen Suchbegriff ein.',
         add_to_metamask: '{ symbol } zu MetaMask hinzufügen',
         tx_hash: 'Txn Hash',
+        direction: 'Richtung',
         block: 'Block',
         date: 'Date Time (UTC)',
         age: 'Age',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -192,6 +192,7 @@ export default {
         search_failed: 'Search failed, please enter a valid search term.',
         add_to_metamask: 'Add { symbol } to MetaMask',
         tx_hash: 'Txn Hash',
+        direction: 'Direction',
         block: 'Block',
         date: 'Date Time (UTC)',
         age: 'Age',

--- a/src/i18n/es-es/index.js
+++ b/src/i18n/es-es/index.js
@@ -241,6 +241,7 @@ export default {
         search_failed: 'La búsqueda falló, ingrese un término de búsqueda válido.',
         add_to_metamask: 'Agregar { symbol } a MetaMask',
         tx_hash: 'Hash de Txn',
+        direction: 'Dirección',
         block: 'Bloque',
         date: 'Date Time (UTC)',
         age: 'Age',

--- a/src/i18n/fr-fr/index.js
+++ b/src/i18n/fr-fr/index.js
@@ -190,6 +190,7 @@ export default {
         search_failed: 'La recherche à échouée, veuillez saisir des mots clés de recherche correctes.',
         add_to_metamask: 'Ajoutez { symbol } à MetaMask',
         tx_hash: 'Transaction',
+        direction: 'Direction',
         block: 'Bloc',
         date: 'Date',
         method: 'Méthode',

--- a/src/i18n/pt-br/index.js
+++ b/src/i18n/pt-br/index.js
@@ -243,6 +243,7 @@ export default {
         search_failed: 'A busca falhou, digite um termo de pesquisa válido.',
         add_to_metamask: 'Adicionar { symbol } ao MetaMask',
         tx_hash: 'Txn Hash',
+        direction: 'Direção',
         block: 'Bloco',
         date: 'Date Time (UTC)',
         age: 'Age',


### PR DESCRIPTION
Fixes #787 

Currently the "Direction" Column isn't capitalized, and has no translations unlike the other columns in the transactions table:

<img width="870" alt="image" src="https://github.com/user-attachments/assets/9d2ace85-6254-422f-aca4-480eddcac04b">

Production example: https://www.teloscan.io/address/0x9c5ebCbE531aA81bD82013aBF97401f5C6111d76?tab=internaltx
Fix here: https://deploy-preview-788--dev-mainnet-teloscan.netlify.app/address/0x9c5ebCbE531aA81bD82013aBF97401f5C6111d76?tab=internaltx

<img width="607" alt="image" src="https://github.com/user-attachments/assets/4a241e9e-303f-486a-8633-11821ce2a11c">

<img width="434" alt="image" src="https://github.com/user-attachments/assets/ac760825-a41d-463f-904c-d1887ba5ae0a">
