### PR TITLE
Make error message to fit container

### DIFF
--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -460,3 +460,15 @@ export default defineComponent({
     </div>
 </div>
 </template>
+
+<style>
+
+.text-negative.output-container {
+    overflow-wrap: break-word;
+    word-break: break-all;
+    overflow: hidden;
+    white-space: pre-wrap;
+}
+
+</style>
+


### PR DESCRIPTION
# Fixes #785

## Description
The style was adjusted so that the error message is displayed inside its container and there is no overflow.

## Test scenarios



![image](https://github.com/user-attachments/assets/6faee7f1-a9aa-47d9-8664-6953410781cc)
