### PR TITLE
#806 | Contract Creation transaction fixed

### DIFF
--- a/src/components/TransactionAction.vue
+++ b/src/components/TransactionAction.vue
@@ -2,7 +2,6 @@
 import { computed, ref, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { ZERO_ADDRESSES } from 'src/lib/utils';
 import MethodField from 'components/MethodField.vue';
 import AddressField from 'components/AddressField.vue';
 import ValueField from 'components/ValueField.vue';
@@ -26,6 +25,7 @@ const props = defineProps({
             to?: string | null;
             input?: string;
             hash?: string;
+            contractAddress?: string | null;
         },
         required: true,
     },
@@ -46,7 +46,7 @@ onMounted(async () => {
 const setValues = async () => {
     if (propValue.value > 0 && props.trx.input === '0x') {
         transactionCase.value = cases.TLOS_TRANSFER;
-    } else if (props.trx.to === null || props.trx.to === ZERO_ADDRESSES) {
+    } else if (props.trx.to === null || props.trx.contractAddress !== null) {
         transactionCase.value = cases.CONTRACT_CREATION;
     } else {
         transactionCase.value = cases.FUNCTION_CALL;

--- a/src/lib/data-export-utils.ts
+++ b/src/lib/data-export-utils.ts
@@ -1,32 +1,6 @@
-// import { contractManager, indexerApi, exportApi } from 'src/boot/telosApi'; // FIXME: uncomment this line
-// import { formatTimestamp } from 'src/lib/date-utils'; // FIXME: uncomment this line
-// import { formatWei } from 'src/lib/utils'; // FIXME: uncomment this line
 import { AxiosError } from 'axios';
 import { exportApi } from 'src/boot/telosApi';
 import { EXPORT_DOWNLOAD_TYPES } from 'src/lib/constants';
-
-// import { EvmTransfer } from 'src/antelope/types/EvmTransaction'; // FIXME: uncomment this line
-
-/**
- * Escape a string value which is meant to be entered into a CSV
- *
- * @param value The value to escape
- * @returns The escaped value
- */
-/* // FIXME: uncomment this line
-function escapeCSVValue(value: string) {
-    let escapedVal = value;
-
-    if (
-        escapedVal.includes(',') ||
-        escapedVal.includes('\n') ||
-        escapedVal.includes('"')
-    ) {
-        escapedVal = `"${escapedVal.replace(/"/g, '""')}"`; // Escape quotes
-    }
-
-    return value;
-}*/
 
 /**
  * Download a CSV file of transactions
@@ -101,7 +75,6 @@ export async function downloadCsv(
     }
 
     try {
-        console.log('url: ', url); // FIXME: remove this line
         const { data } = await exportApi.get(url);
         csvContent = data;
     } catch (e) {

--- a/src/lib/transaction-utils.ts
+++ b/src/lib/transaction-utils.ts
@@ -11,6 +11,7 @@ import { WEI_PRECISION, formatWei, parseErrorMessage } from 'src/lib/utils';
 import { toChecksumAddress } from 'src/lib/utils';
 
 export const tryToExtractMethod = (abi: {[hash: string]: string }, input: string) => {
+    console.log('tryToExtractMethod() -------->', abi, input);
     if (!abi || !input) {
         return undefined;
     }

--- a/src/lib/transaction-utils.ts
+++ b/src/lib/transaction-utils.ts
@@ -11,7 +11,6 @@ import { WEI_PRECISION, formatWei, parseErrorMessage } from 'src/lib/utils';
 import { toChecksumAddress } from 'src/lib/utils';
 
 export const tryToExtractMethod = (abi: {[hash: string]: string }, input: string) => {
-    console.log('tryToExtractMethod() -------->', abi, input);
     if (!abi || !input) {
         return undefined;
     }


### PR DESCRIPTION
# Fixes #806

## Description
This PR correctly distinguishes between a [Contract Creation transaction](https://www.teloscan.io/tx/0x732d95e9854ca426bc042479327bd4f88f2eb1a885e5bd69259695b80a65b7a3), a [normal TLOS transfer](https://www.teloscan.io/tx/0x3622917b7cac6bd052755feeeae6046921849213484837b3051995a376a2985b) and a [TLOS transfer to null address with parameters](https://www.teloscan.io/tx/0x0d5177bc7bb83e4ee84a17421e74d32d4b26c3d17eaca20d30adfaf26780aa39)

In the case of a contract being created, it replaces the receiver (to) field with the contract address.



## Test scenarios
- check [normal TLOS transfer](https://deploy-preview-809--dev-mainnet-teloscan.netlify.app/tx/0x3622917b7cac6bd052755feeeae6046921849213484837b3051995a376a2985b)  

  ![image](https://github.com/user-attachments/assets/ca230697-062d-469d-b03d-2ffe3cd2d267)

- check [TLOS transfer to null address with parameters](https://deploy-preview-809--dev-mainnet-teloscan.netlify.app/tx/0x0d5177bc7bb83e4ee84a17421e74d32d4b26c3d17eaca20d30adfaf26780aa39)   

  ![image](https://github.com/user-attachments/assets/24a715a0-cb51-4413-bca8-860e427b6cab)

- check [Contract Creation transaction](https://deploy-preview-809--dev-mainnet-teloscan.netlify.app/tx/0x732d95e9854ca426bc042479327bd4f88f2eb1a885e5bd69259695b80a65b7a3)  

  ![image](https://github.com/user-attachments/assets/976c9991-8405-474d-9a07-dad1ab2f5fad)

