### PR TITLE
#817 | Broken token cards were restyled.

### DIFF
--- a/src/components/Token/TokenGridElement.vue
+++ b/src/components/Token/TokenGridElement.vue
@@ -29,9 +29,7 @@ export default {
             </q-avatar>
             <div class="c-token__info">
                 <div class="c-token__name-container" :title="element.name">
-                    <span>
-                        <div class="c-token__name">{{ this.token.name }}</div>
-                    </span>
+                    <div class="c-token__name">{{ this.token.name }}</div>
                     <AddressField
                         :truncate="16"
                         :address="element.address"
@@ -39,7 +37,6 @@ export default {
                         :useHighlight="false"
                         class="c-token__address"
                     />
-
                 </div>
                 <div class="c-token__numbers">
                     <div class="c-token__numbers-balance">
@@ -72,6 +69,7 @@ export default {
 
 <style lang="scss">
 .c-token {
+    overflow: auto;
     &__token-card {
         display: block;
     }
@@ -81,6 +79,7 @@ export default {
     &__token-card-avatar {
         margin: 0px 10px;
         height: auto;
+        flex-shrink: 0;
     }
     &__token-card-icon {
         width: 100% !important;
@@ -88,11 +87,14 @@ export default {
     }
     &__info {
         flex-grow: 1;
+        min-width: 0;
     }
     &__name-container {
         display: flex;
         flex-direction: column;
         align-items: baseline;
+        max-width: 100%;
+        overflow: hidden;
     }
     &__name {
         font-size: 1.25rem;
@@ -102,6 +104,7 @@ export default {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        max-width: 100%;
     }
     &__address {
         display: block;

--- a/src/components/Token/TokenGridElement.vue
+++ b/src/components/Token/TokenGridElement.vue
@@ -21,30 +21,28 @@ export default {
 </script>
 
 <template>
-<div v-if="element?.balance" class="c-token-list__token-card">
-    <q-card >
-        <q-card-section class="flex">
-            <q-avatar class="q-mr-md">
-                <img :src="element.logoURI" :alt="element.name + ' Token Logo'">
+<div v-if="element?.balance" class="c-token">
+    <q-card class="c-token__token-card">
+        <q-card-section class="c-token__token-card-section">
+            <q-avatar class="c-token__token-card-avatar">
+                <q-img :src="element.logoURI" :alt="element.name + ' Token Logo'" class="c-token__token-card-icon" />
             </q-avatar>
-            <div class="c-token-list__token-info-container">
-                <div class="text-h6 c-token-list__token-name" :title="element.name">
-                    <span v-if="element.name.length < 17">{{ this.token.name }}</span>
-                    <span v-else>
-                        <span>{{ this.token.name.slice(0, 17) }}</span>
-                        <span>...</span>
-                        <q-tooltip>{{ this.token.name }}</q-tooltip>
+            <div class="c-token__info">
+                <div class="c-token__name-container" :title="element.name">
+                    <span>
+                        <div class="c-token__name">{{ this.token.name }}</div>
                     </span>
+                    <AddressField
+                        :truncate="16"
+                        :address="element.address"
+                        :name="symbol"
+                        :useHighlight="false"
+                        class="c-token__address"
+                    />
+
                 </div>
-                <AddressField
-                    :truncate="16"
-                    :address="element.address"
-                    :name="symbol"
-                    class="q-mb-sm"
-                    :useHighlight="false"
-                />
-                <div>
-                    <div class="flex">
+                <div class="c-token__numbers">
+                    <div class="c-token__numbers-balance">
                         <span v-if="element.balance === '0.0000' && element.fullBalance > 0">
                             {{ '< 0.0001 ' + symbol }}
                         </span>
@@ -55,7 +53,7 @@ export default {
                             {{ element.fullBalance + ' ' + symbol || $t('components.error_fetching_balance') }}
                         </q-tooltip>
                     </div>
-                    <div class="text-grey q-mb-sm">
+                    <div class="c-token__numbers-usd">
                         <span v-if="element.valueUSD" >{{ element.valueUSD }} $</span>
                         <span v-else>-</span>
                     </div>
@@ -64,6 +62,7 @@ export default {
                     :token="element"
                     :icon="false"
                     :label="$t('components.add_to_metamask', { symbol: symbol })"
+                    class="c-token__add-to-wallet"
                 />
             </div>
         </q-card-section>
@@ -72,21 +71,54 @@ export default {
 </template>
 
 <style lang="scss">
-.c-token-list {
+.c-token {
     &__token-card {
-        min-width: 0;
-        .text-grey {
-            font-size: 0.8em;
-        }
+        display: block;
     }
-    &__token-name {
+    &__token-card-section {
+        display: flex;
+    }
+    &__token-card-avatar {
+        margin: 0px 10px;
+        height: auto;
+    }
+    &__token-card-icon {
+        width: 100% !important;
+        height: auto !important;
+    }
+    &__info {
+        flex-grow: 1;
+    }
+    &__name-container {
+        display: flex;
+        flex-direction: column;
+        align-items: baseline;
+    }
+    &__name {
+        font-size: 1.25rem;
+        font-weight: 500;
+        letter-spacing: .0125em;
+        line-height: 2rem;
+        white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
     }
-
-    &__token-info-container {
-        overflow: hidden;
-        white-space: nowrap;
+    &__address {
+        display: block;
+    }
+    &__numbers {
+        display: block;
+        &-balance {
+            display: block;
+        }
+        &-usd {
+            display: block;
+            color: var(--grey-text-color);
+            font-size: 0.86em;
+        }
+    }
+    &__add-to-wallet {
+        display: block;
     }
 }
 </style>


### PR DESCRIPTION
# Fixes #817

## Description
Broken token cards were restyled. Now they look better and use the whole space available.

## Test scenarios
Activate the grid mode on the Tokens tab
https://deploy-preview-826--dev-mainnet-teloscan.netlify.app/address/0xa30b5e3c8Fee56C135Aecb733cd708cC31A5657a?tab=tokens

## Screenshots

![image](https://github.com/user-attachments/assets/708faf9c-fd99-4b6c-b1e3-e9d761cfacfc)


