### PR TITLE
checksum acceptance criteria for filtering address removed

### DIFF
--- a/src/components/AppSearch.vue
+++ b/src/components/AppSearch.vue
@@ -97,7 +97,6 @@ const resolveIcon = (entry: SearchResultToken): string => {
 };
 
 const convertRawToProcessedResult = (entry: SearchResultRaw): SearchResult => {
-    console.log('convertRawToProcessedResult()', entry);
     const address = entry.address ?? NULL_ADDRESS;
     switch (resolveCategory(entry)) {
     case 'contract':

--- a/src/components/AppSearch.vue
+++ b/src/components/AppSearch.vue
@@ -2,7 +2,6 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { toChecksumAddress } from 'src/lib/utils';
 import { TokenList } from 'src/types';
 import axios from 'axios';
 
@@ -98,6 +97,7 @@ const resolveIcon = (entry: SearchResultToken): string => {
 };
 
 const convertRawToProcessedResult = (entry: SearchResultRaw): SearchResult => {
+    console.log('convertRawToProcessedResult()', entry);
     const address = entry.address ?? NULL_ADDRESS;
     switch (resolveCategory(entry)) {
     case 'contract':
@@ -274,9 +274,6 @@ const extractCategoryList = (): SearchResultCategory[] =>
 
 const filterResults = (results: SearchResult[]): SearchResult[] => results.filter((result) => {
     let accepted = true;
-    if (result.category === 'address') {
-        accepted = result.address === toChecksumAddress(result.address);
-    }
     if (accepted) {
         return accepted;
     } else {


### PR DESCRIPTION
# Fixes #837

## Description
At the beginning, the Indexer API was returning each address twice (one in lowercase and the other one in checksum format). That is why we were filtering only the checksum formatted addresses. But now it only returns the lowercase format, so no address results are shown because all of them were filtered out. Now that is fixed, and no filtering is performed at all.

## Test scenarios
1 - go to [this deployment link](https://deploy-preview-838--dev-mainnet-teloscan.netlify.app/)
2 - enter: 0x31644692d2c2b7228f9763416e7612451F69009e or any other valid address
3 - see one result

![image](https://github.com/user-attachments/assets/630106b7-033c-4530-8835-b6a04edb5624)

