### PR TITLE
Hotfix for #845 and #844

### DIFF
--- a/src/components/AddressOverview.vue
+++ b/src/components/AddressOverview.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import { useStore } from 'vuex';
 import { useI18n } from 'vue-i18n';
-import { WEI_PRECISION } from 'src/lib/utils';
 import { prettyPrintFiatBalance } from 'src/antelope/wallets/utils';
 import { useChainStore } from 'src/antelope';
 import { SystemBalance } from 'src/lib/balance-utils';
@@ -27,7 +26,6 @@ function getBalanceDisplay(balance: string, symbol: string) {
 }
 
 const systemToken = useChainStore().currentChain.settings.getSystemToken();
-
 </script>
 
 <template>
@@ -46,11 +44,6 @@ const systemToken = useChainStore().currentChain.settings.getSystemToken();
                     width="18"
                 >
                 {{ getBalanceDisplay(props.balance.tokenQty, systemToken.symbol) }}
-                <ValueField
-                    :value="props.balance.tokenQty"
-                    :symbol="systemToken.symbol"
-                    :decimals="WEI_PRECISION"
-                />
             </div>
         </q-card-section>
         <q-card-section v-if="!loadingComplete" >

--- a/src/components/AppSearch.vue
+++ b/src/components/AppSearch.vue
@@ -2,6 +2,7 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { toChecksumAddress } from 'src/lib/utils';
 import { TokenList } from 'src/types';
 import axios from 'axios';
 
@@ -273,6 +274,9 @@ const extractCategoryList = (): SearchResultCategory[] =>
 
 const filterResults = (results: SearchResult[]): SearchResult[] => results.filter((result) => {
     let accepted = true;
+    if (result.category === 'address') {
+        accepted = result.address === toChecksumAddress(result.address);
+    }
     if (accepted) {
         return accepted;
     } else {

--- a/src/lib/contract/ContractManager.js
+++ b/src/lib/contract/ContractManager.js
@@ -66,6 +66,8 @@ class AddressCacheManager {
             this.contractInfoByNetwork[network][addressLower] = info;
             this.saveToLocalStorage();
         }
+
+        this.removeNullAddress(address);
     }
 
     exists(address) {
@@ -80,7 +82,7 @@ class AddressCacheManager {
         return this.contractInfoByNetwork[network] && this.contractInfoByNetwork[network][addressLower];
     }
 
-    removeAddress(address) {
+    removeNullAddress(address) {
         const addressLower = typeof address === 'string' ? address.toLowerCase() : '';
         const network = this.getCurrentNetwork();
         if (this.addressesByNetwork[network]) {
@@ -299,10 +301,11 @@ export default class ContractManager {
             return;
         }
         let contract = this.factory.buildContract(contractData);
+
         if(
-            typeof this.getNetworkContract(index) === 'undefined'
-            || contract.abi?.length > 0 && !this.getNetworkContract(index).abi
-            || contract.abi?.length > 0 && contract.abi.length > this.getNetworkContract(index).abi?.length
+            !this.getNetworkContract(index) && contract?.name
+            || contract.abi?.length > 0 && !this.getNetworkContract(index)?.abi
+            || contract.abi?.length > 0 && contract.abi.length > (this.getNetworkContract(index)?.abi?.length || 0)
         ){
             this.setNetworkContract(index, contract);
         }


### PR DESCRIPTION
# Fixes #845 and #844

## Description
The problem in #844 was caused by a null value stored in my local cache. Fortunately, it affected only me but it would eventually affect others with time. So the code causing the bug was fixed (regardless of the cache values).

The problem with the double result was fixed by restoring the filter that was previously removed.

Also, there was an unnecessary ValueField component that was not used and was causing a warning on the console. That component was removed.

## Screenshots 
![image](https://github.com/user-attachments/assets/f6bc5694-a53c-492b-962f-647a4dadb59d)

![image](https://github.com/user-attachments/assets/dc804ae5-cb2d-4c60-aa5b-1f247fabb263)
