### PR TITLE
#816 | change the strategy to only fetch contracts from cache

### DIFF
--- a/src/lib/contract/ContractManager.js
+++ b/src/lib/contract/ContractManager.js
@@ -387,10 +387,8 @@ export default class ContractManager {
         } else if (this.nullContractsManager.existsContract(addressLower)) {
             result = this.nullContractsManager.getContractInfo(addressLower);
         } else {
-            result = await this.getContract(addressLower);
-            if (result) {
-                result = this.nullContractsManager.getContractInfo(addressLower);
-            }
+            // We are going to always assume that if the address is a contract, it is already in the cache
+            // Because the indexer API should always return all involved contracts in a query response
         }
         return result;
     }


### PR DESCRIPTION
# Fixes #816

## Description
The current implementation has a minimal difference. Now, each time we need to display an address, we take the possible contract metadata from the local cache, delegating to the indexer API the responsibility of populating that cache on each query.

# Test Scenarios
You can test this now on the mainnet on the USDT holders page:

- Go to https://deploy-preview-850--dev-mainnet-teloscan.netlify.app/address/0x975Ed13fa16857E83e7C493C7741D556eaaD4A3f
- Open the developer tools (F12) in the Network section and clear everything.
- Go to the Holders tab.
- Confirm that there's no extra query to fetch each address.
- Navigate through the pages and ensure there's no extra query for unknown addresses.
