### PR TITLE
#853 | home page includes the contract metadata on the last 6 trx query

### DIFF
--- a/src/pages/home/HomeLatestTransactions.vue
+++ b/src/pages/home/HomeLatestTransactions.vue
@@ -33,7 +33,7 @@ const loading = ref(true);
 const truncateHash = computed(() => $q.screen.width > 1024 && $q.screen.width <= 1240 ? 8 : 20);
 
 onBeforeMount(async () => {
-    const response = await indexerApi.get('transactions?limit=6');
+    const response = await indexerApi.get('transactions?limit=6&includeAbi=true');
     transactions.value = response.data.results;
     loading.value = false;
 });


### PR DESCRIPTION
# Fixes #553

## Description
The query for the last 6 transactions was adjusted to include the metadata necessary to display the contracts names avoiding the following queries for each address involved.

## Test scenarios
