### PR TITLE
#847 | amount of loading columns for transactions page fixed

### DIFF
--- a/src/components/TransactionTable.vue
+++ b/src/components/TransactionTable.vue
@@ -527,7 +527,7 @@ onBeforeMount(() => {
                 <q-td key="date">
                     <q-skeleton type="text" class="c-trx-overview__skeleton" />
                 </q-td>
-                <q-td key="direction" >
+                <q-td v-if="accountAddress" key="direction">
                     <q-skeleton type="text" class="c-trx-overview__skeleton" />
                 </q-td>
                 <q-td key="from"  class="c-transaction-table__cell">


### PR DESCRIPTION
# Fixes #847

## Description
The Transactions Page and Address Page on the Transactions tab use the same component TransactionsTable with different columns depending on the context. This PR fixes the amount of loading columns for that Transaction Page In which the direction column is not used.

## Test scenarios

### Transaction Page
https://deploy-preview-855--testnet-teloscan.netlify.app/txs
![image](https://github.com/user-attachments/assets/99e61e43-af30-4bb8-a500-f46fddfa8437)


### Address PAge - Transactions Tab
https://deploy-preview-855--testnet-teloscan.netlify.app/address/0x5E1BE25D4A2De0083012f1B5A8030a7023fFA5bc
![image](https://github.com/user-attachments/assets/86891fc9-6a4c-4c99-bd70-c989bbf63ea1)
