### PR TITLE
#858 | The address page now shows feedback immediately

### DIFF
--- a/src/components/AddressMoreInfo.vue
+++ b/src/components/AddressMoreInfo.vue
@@ -38,40 +38,40 @@ onBeforeMount(async () => {
 </script>
 
 <template>
-<q-card class="c-more-info">
+<q-card class="c-address-more-info">
     <q-card-section v-if="!loadingComplete" >
         <q-skeleton type="text" class="c-overview__skeleton" />
     </q-card-section>
     <q-card-section v-else>
-        <div class="c-more-info__section-label">
+        <div class="c-address-more-info__section-label">
             {{ $t('pages.last') }} {{ $t('pages.transaction_sent') }}
         </div>
         <TransactionField
             color="primary"
             :transaction-hash="lastTxn"
             :truncate="18"
-            class="c-more-info__value"
+            class="c-address-more-info__value"
         />
     </q-card-section>
     <q-card-section v-if="!loadingComplete" >
         <q-skeleton type="text" class="c-overview__skeleton" />
     </q-card-section>
     <q-card-section v-else>
-        <div class="c-more-info__section-label">
+        <div class="c-address-more-info__section-label">
             {{ $t('pages.first') }} {{ $t('pages.transaction_sent') }}
         </div>
         <TransactionField
             color="primary"
             :transaction-hash="firstTxn"
             :truncate="18"
-            class="c-more-info__value"
+            class="c-address-more-info__value"
         />
     </q-card-section>
 </q-card>
 </template>
 
 <style lang="scss">
-.c-more-info {
+.c-address-more-info {
     height:100%;
     &__section-label {
         font-weight: 600;

--- a/src/components/AddressOverview.vue
+++ b/src/components/AddressOverview.vue
@@ -29,42 +29,41 @@ const systemToken = useChainStore().currentChain.settings.getSystemToken();
 </script>
 
 <template>
-<div>
-    <q-card class="c-overview">
-        <q-card-section v-if="!loadingComplete" >
-            <q-skeleton type="text" class="c-overview__skeleton" />
-        </q-card-section>
-        <q-card-section v-else>
-            <div class="c-overview__label"> TLOS {{ $t('pages.balance') }} </div>
-            <div class="c-overview__balance">
-                <img
-                    src="branding/telos.png"
-                    alt="TLOS"
-                    height="18"
-                    width="18"
-                >
-                {{ getBalanceDisplay(props.balance.tokenQty, systemToken.symbol) }}
-            </div>
-        </q-card-section>
-        <q-card-section v-if="!loadingComplete" >
-            <q-skeleton type="text" class="c-overview__skeleton" />
-        </q-card-section>
-        <q-card-section v-else>
-            <div class="c-overview__label">
-                {{ systemToken.symbol }} {{ $t('pages.value') }}
-            </div>
-            <div class="c-overview__balance"> {{ prettyPrintFiatBalance(props.balance.fiatValue, 'us', false) }} (@ ${{ fiatPrice }}/{{ systemToken.symbol }})</div>
-        </q-card-section>
-    </q-card>
-</div>
+<q-card class="c-address-overview">
+    <q-card-section v-if="!loadingComplete" >
+        <q-skeleton type="text" class="c-address-overview__skeleton" />
+    </q-card-section>
+    <q-card-section v-else>
+        <div class="c-address-overview__label"> TLOS {{ $t('pages.balance') }} </div>
+        <div class="c-address-overview__balance">
+            <img
+                src="branding/telos.png"
+                alt="TLOS"
+                height="18"
+                width="18"
+            >
+            {{ getBalanceDisplay(props.balance.tokenQty, systemToken.symbol) }}
+        </div>
+    </q-card-section>
+    <q-card-section v-if="!loadingComplete" >
+        <q-skeleton type="text" class="c-address-overview__skeleton" />
+    </q-card-section>
+    <q-card-section v-else>
+        <div class="c-address-overview__label">
+            {{ systemToken.symbol }} {{ $t('pages.value') }}
+        </div>
+        <div class="c-address-overview__balance"> {{ prettyPrintFiatBalance(props.balance.fiatValue, 'us', false) }} (@ ${{ fiatPrice }}/{{ systemToken.symbol }})</div>
+    </q-card-section>
+</q-card>
 </template>
 
 <style lang="scss">
-.c-overview{
-    &__balance{
+.c-address-overview {
+    height: 100%;
+    &__balance {
         display: flex;
     }
-    &__label{
+    &__label {
         font-weight: 600;
         font-size: 0.8rem;
     }
@@ -75,14 +74,14 @@ const systemToken = useChainStore().currentChain.settings.getSystemToken();
             width: 50%;
         }
     }
-    img{
+    img {
         margin-right: 2px;
     }
 }
 
 @-moz-document url-prefix() {
-    .c-overview{
-        &__label{
+    .c-address-overview {
+        &__label {
             font-weight: 1000;
         }
     }

--- a/src/components/ContractMoreInfo.vue
+++ b/src/components/ContractMoreInfo.vue
@@ -25,12 +25,12 @@ const props = defineProps({
 </script>
 
 <template>
-<q-card class="c-more-info">
+<q-card class="c-contract-more-info">
     <q-card-section v-if="!loadingComplete" >
         <q-skeleton type="text" class="c-overview__skeleton" />
     </q-card-section>
-    <q-card-section v-else class="c-more-info__section">
-        <div class="c-more-info__creator">
+    <q-card-section v-else class="c-contract-more-info__section">
+        <div class="c-contract-more-info__creator">
             {{ $t('pages.contract_creator') }}
         </div>
         <AddressField
@@ -42,9 +42,9 @@ const props = defineProps({
             :text="props.address"
             accompanyingText=""
             description="creator address"
-            class="c-more-info__copy"
+            class="c-contract-more-info__copy"
         />
-        <div class="c-more-info__at-txn c-more-info__value">at txn</div>
+        <div class="c-contract-more-info__at-txn c-contract-more-info__value">at txn</div>
         <TransactionField
             :transaction-hash="props.transaction"
         />
@@ -53,19 +53,19 @@ const props = defineProps({
 </template>
 
 <style lang="scss">
-.c-more-info{
+.c-contract-more-info {
     height:100%;
 
-    &__copy{
+    &__copy {
         display: inline;
         font-size: 16px;
     }
-    &__creator{
+    &__creator {
         font-weight: 600;
         font-size: 0.8rem;
         text-transform: capitalize;
     }
-    &__at-txn{
+    &__at-txn {
         display: inline-flex;
         text-transform: lowercase;
         margin-right: .25rem;
@@ -81,8 +81,8 @@ const props = defineProps({
 }
 
 @-moz-document url-prefix() {
-    .c-more-info{
-        &__creator{
+    .c-contract-more-info {
+        &__creator {
             font-weight: 1000;
         }
     }

--- a/src/pages/AccountPage.vue
+++ b/src/pages/AccountPage.vue
@@ -138,13 +138,19 @@ async function loadAccount() {
 </script>
 
 <template>
-<div v-if="accountAddress && !accountLoading" :key="accountAddress" class="c-address q-pt-xl">
+<div v-if="accountAddress" :key="accountAddress" class="c-address q-pt-xl">
     <div class="row justify-between q-mb-lg">
         <div class="col-12">
             <div class="c-address__header">
                 <div class="c-address__header-text-container">
+                    <q-spinner
+                        v-if="accountLoading"
+                        class="c-address__header-spinner"
+                        color="primary"
+                        size="sm"
+                    />
                     <q-img
-                        v-if="contract && contract.supportedInterfaces?.includes('erc20')"
+                        v-else-if="contract && contract.supportedInterfaces?.includes('erc20')"
                         class="c-address__coin-icon"
                         :alt="contract.getName() + ' ERC20 token'"
                         :src="getIcon(contract.logoURI)"
@@ -452,6 +458,10 @@ async function loadAccount() {
         align-items: center;
         gap: 12px;
         flex-wrap: wrap;
+        &-spinner {
+            margin-bottom: 3px;
+        }
+
     }
 
     &__header-text-container {


### PR DESCRIPTION
# Fixes #858

## Description
The address page was modified to show the basic structure although it still does not have the data to show. It shows spinners and loading skeletons instead.

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage
-   [ ] I have updated relevant documentation and/or opened a separate issue to cover the updates (Issue URL: )
