### PR TITLE
#856 | Transactions page pagination fixed to show the fery first page

### DIFF
--- a/src/components/TransactionTable.vue
+++ b/src/components/TransactionTable.vue
@@ -274,7 +274,10 @@ async function getPath() {
             const firstKey = response.data.results[0]?.id || 0;
             pagination.value.initialKey = firstKey + 1;
         }
-        const currentKey = pagination.value.initialKey - ((page - 1) * rowsPerPage);
+        let currentKey = pagination.value.initialKey - ((page - 1) * rowsPerPage);
+        if (currentKey < 0) {
+            currentKey = rowsPerPage + 1;
+        }
         path += `&key=${currentKey}`;
     }
 


### PR DESCRIPTION
# Fixes #856

## Description
There was an overflow in the calculation of the key to use on the query when trying to access the last (first in time) page of transactions. It was fixed to equal the page size in case of overflow.

## Test scenarios
1. Go to [Transaction Page](https://deploy-preview-861--dev-mainnet-teloscan.netlify.app/txs)
2. Scroll down to pagination buttons
3. click on the last page
4. see the last block number
