### PR TITLE
#829 | address page has blockie icon (based on address)

### DIFF
--- a/src/components/AppSearch.vue
+++ b/src/components/AppSearch.vue
@@ -591,7 +591,7 @@ const handleResultClick = (item: SearchResult): void => {
         <div class="c-search__results">
             <template
                 v-for="(entry, index) in searchResults"
-                :key="entry.address ?? entry.hash"
+                :key="(entry.address) ?? entry.hash"
             >
                 <div
                     v-if="shouldShowDivider(index)"

--- a/src/components/AppSearchResultEntry.vue
+++ b/src/components/AppSearchResultEntry.vue
@@ -11,8 +11,8 @@ import {
     SearchResultUnknown,
 } from 'src/types';
 
-import { createIcon } from '@download/blockies';
 import { computed } from 'vue';
+import { createIconFromData } from 'src/lib/blockies/blockies';
 
 const props = defineProps<{
     entry: SearchResult,
@@ -40,15 +40,7 @@ const item = {
     unknown: asUnknown(props.entry),
 };
 
-const createIconFromData = (data: string) => {
-    // https://github.com/download13/blockies
-    var imgData = createIcon({
-        seed: data,
-        size: 8,
-        scale: 3,
-    }).toDataURL();
-    return imgData;
-};
+
 
 const emit = defineEmits(['click']);
 

--- a/src/components/MethodField.vue
+++ b/src/components/MethodField.vue
@@ -132,7 +132,7 @@ const setValues = async () => {
 
 <style lang="scss">
 .c-method {
-    width: 80px;
+    width: 150px;
     height: 24px;
     text-overflow: ellipsis;
     overflow: hidden;

--- a/src/lib/blockies/blockies.ts
+++ b/src/lib/blockies/blockies.ts
@@ -1,0 +1,11 @@
+import { createIcon } from '@download/blockies';
+
+export const createIconFromData = (data: string) => {
+    // https://github.com/download13/blockies
+    const imgData = createIcon({
+        seed: data,
+        size: 8,
+        scale: 3,
+    }).toDataURL();
+    return imgData;
+};

--- a/src/pages/AccountPage.vue
+++ b/src/pages/AccountPage.vue
@@ -7,6 +7,7 @@ import { contractManager } from 'src/boot/telosApi';
 import { evm } from 'src/boot/evm';
 import { toChecksumAddress } from 'src/lib/utils';
 import { SystemBalance, getSystemBalance } from 'src/lib/balance-utils';
+import { createIconFromData } from 'src/lib/blockies/blockies';
 import { getIcon } from 'src/lib/token-utils';
 import { Token } from 'src/types/Token';
 
@@ -155,6 +156,13 @@ async function loadAccount() {
                         :alt="contract.getName() + ' ERC20 token'"
                         :src="getIcon(contract.logoURI)"
                     />
+                    <img
+                        v-else
+                        :src="createIconFromData(accountAddress)"
+                        alt=""
+                        class="c-address__icon"
+                    >
+                    <!--
                     <q-icon
                         v-else-if="!contract"
                         name="account_circle"
@@ -165,6 +173,7 @@ async function loadAccount() {
                         :name="(contract.supportedInterfaces?.includes('erc721')) ? 'perm_media' : 'source'"
                         size="sm"
                     />
+                    -->
                     <span class="c-address__title">{{ title }}</span>
                     <span class="c-address__hex">{{ accountAddress }}</span>
                     <q-tooltip v-if="fullTitle" anchor="top middle" self="bottom middle">{{ fullTitle }} </q-tooltip>
@@ -419,6 +428,13 @@ async function loadAccount() {
 <style lang="scss">
 .c-address {
     @include page-container;
+
+    &__icon {
+        width: 22px;
+        height: 22px;
+        margin-right: 2px;
+        border-radius: 50%;
+    }
 
     &__info-container{
         margin-bottom: 2.5rem;

--- a/src/pages/AccountPage.vue
+++ b/src/pages/AccountPage.vue
@@ -156,10 +156,11 @@ async function loadAccount() {
                         :alt="contract.getName() + ' ERC20 token'"
                         :src="getIcon(contract.logoURI)"
                     />
+                    <!-- Blockies icon for address + {{accountAddress}} -->
                     <img
                         v-else
                         :src="createIconFromData(accountAddress)"
-                        alt=""
+                        :alt="`Blockies icon for address ${accountAddress}`"
                         class="c-address__icon"
                     >
                     <!--


### PR DESCRIPTION
# Fixes #829

## Description
- The icon for the Address page was changed for a blockie-icon in case of a contract or normal address. In case of a ERC-20 it shows the normal token Icon.
- The field width for the function name was raised to show more complete names.

## Test scenarios
- Address: https://deploy-preview-868--dev-mainnet-teloscan.netlify.app/address/0x77F0Db20D64051D081170e95fC0d0F5aa40C249c
- Contract: https://deploy-preview-868--dev-mainnet-teloscan.netlify.app/address/0x3B7023f3C99EAe2FA0AaeB9490A78d5D98a24148
- Token: https://deploy-preview-868--dev-mainnet-teloscan.netlify.app/address/0xB4B01216a5Bc8F1C8A33CD990A1239030E60C905?tab=transactions

![image](https://github.com/user-attachments/assets/f8fbcbf1-147d-4305-ba59-96fdf2010b47)
