### PR TITLE
#875 | adding the case for no transaction history on address page

### DIFF
--- a/src/i18n/de-de/index.js
+++ b/src/i18n/de-de/index.js
@@ -151,6 +151,7 @@ export default {
         overview: 'Übersicht',
         more_info: 'mehr Infos',
         transaction_sent: 'txn gesendet',
+        no_transactions_yet: 'Noch keine Transaktionen',
         first: 'erste',
         last: 'zuletzt',
         contract_creator: 'Vertragsersteller',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -151,6 +151,7 @@ export default {
         overview: 'overview',
         more_info: 'more info',
         transaction_sent: 'txn sent',
+        no_transactions_yet: 'No transactions yet',
         first: 'first',
         last: 'last',
         contract_creator: 'contract creator',

--- a/src/i18n/es-es/index.js
+++ b/src/i18n/es-es/index.js
@@ -151,6 +151,7 @@ export default {
         overview: 'visión general',
         more_info: 'más información',
         transaction_sent: 'txn enviado',
+        no_transactions_yet: 'Aún no hay transacciones',
         first: 'primero',
         last: 'último',
         contract_creator: 'creador del contrato',

--- a/src/i18n/fr-fr/index.js
+++ b/src/i18n/fr-fr/index.js
@@ -151,6 +151,7 @@ export default {
         overview: 'aperçu',
         more_info: 'plus d\'info',
         transaction_sent: 'txn envoyé',
+        no_transactions_yet: 'Aucune transaction pour le moment',
         first: 'premier',
         last: 'dernier',
         contract_creator: 'créateur de contrat',

--- a/src/i18n/pt-br/index.js
+++ b/src/i18n/pt-br/index.js
@@ -151,6 +151,7 @@ export default {
         overview: 'visão geral',
         more_info: 'mais informações',
         transaction_sent: 'txn enviado',
+        no_transactions_yet: 'Ainda não há transações',
         first: 'primeiro',
         last: 'último',
         contract_creator: 'criador do contrato',

--- a/src/pages/AccountPage.vue
+++ b/src/pages/AccountPage.vue
@@ -163,18 +163,6 @@ async function loadAccount() {
                         :alt="`Blockies icon for address ${accountAddress}`"
                         class="c-address__icon"
                     >
-                    <!--
-                    <q-icon
-                        v-else-if="!contract"
-                        name="account_circle"
-                        size="sm"
-                    />
-                    <q-icon
-                        v-else
-                        :name="(contract.supportedInterfaces?.includes('erc721')) ? 'perm_media' : 'source'"
-                        size="sm"
-                    />
-                    -->
                     <span class="c-address__title">{{ title }}</span>
                     <span class="c-address__hex">{{ accountAddress }}</span>
                     <q-tooltip v-if="fullTitle" anchor="top middle" self="bottom middle">{{ fullTitle }} </q-tooltip>


### PR DESCRIPTION
# Fixes #875

## Description
This PR does not fix the main problem. It only adds a new case in which the consulted address has no transaction registered in history. But the main problem remains and it's on the server side.

The API is returning no transaction history for this particular address.

## Test scenarios
https://deploy-preview-876--dev-mainnet-teloscan.netlify.app/address/0xe0740E654B33550712E192c00C857D64Ce675Af3
![image](https://github.com/user-attachments/assets/4d8b9ab9-976b-4a89-beea-68e22685f96e)
