### PR TITLE
#892 | fixing icon-balance row

### DIFF
--- a/src/components/AddressOverview.vue
+++ b/src/components/AddressOverview.vue
@@ -34,11 +34,11 @@ const systemToken = useChainStore().currentChain.settings.getSystemToken();
         <q-skeleton type="text" class="c-address-overview__skeleton" />
     </q-card-section>
     <q-card-section v-else>
-        <div class="c-address-overview__label"> TLOS {{ $t('pages.balance') }} </div>
+        <div class="c-address-overview__label"> {{ systemToken.symbol }} {{ $t('pages.balance') }} </div>
         <div class="c-address-overview__balance">
             <img
                 src="branding/telos.png"
-                alt="TLOS"
+                :alt="systemToken.symbol"
                 height="18"
                 width="18"
             >
@@ -62,8 +62,8 @@ const systemToken = useChainStore().currentChain.settings.getSystemToken();
     height: 100%;
     &__balance {
         display: flex;
-        flex-direction: column;
-        gap: 5px;
+        flex-direction: row;
+        gap: 3px;
     }
     &__balance-value {
         display: flex;


### PR DESCRIPTION
# Fixes #892

## Description
The balance line was displayed as a column, making the icon and balance text aligned vertically instead of horizontally. This PR fixes that and also makes a forgotten hard-coded TLOS symbol to be dynamic, depending on the selected network.

## Test scenarios

https://deploy-preview-894--dev-mainnet-teloscan.netlify.app/address/0x45cB7B68F22A8CeD95305e21F451BFD0f499242e?network=telos-evm

![image](https://github.com/user-attachments/assets/8a3e3465-4c24-4f13-8d8d-1806e498ef29)
