### PR TITLE
#897 | disabled query button fixed for simple read functions

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -36,7 +36,7 @@ module.exports = function(/* ctx */) {
             'errorHandling',
             'evm',
             'q-component-defaults',
-            'antelope',
+            'core',
         ],
 
         // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-css

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@ import { useI18n } from 'vue-i18n';
 import { useQuasar } from 'quasar';
 import moment from 'moment';
 
-import { getAntelope, useChainStore } from 'src/core';
+import { getCore, useChainStore } from 'src/core';
 import { TELOS_NETWORK_NAMES } from 'src/core/mocks/chain-constants';
 import { providerManager } from 'src/boot/evm';
 
@@ -54,14 +54,14 @@ onMounted(async () => {
     }
 
     // On login we must set the address and record the provider
-    getAntelope().events.onLoggedOut.subscribe(() => {
+    getCore().events.onLoggedOut.subscribe(() => {
         const loginData = localStorage.getItem('loginData');
         if (isNative.value) {
             if (!loginData) {
                 return;
             }
             const loginObj = JSON.parse(loginData);
-            const wallet = getAntelope().config.authenticatorsGetter().find(a => a.getName() === loginObj.provider);
+            const wallet = getCore().config.authenticatorsGetter().find(a => a.getName() === loginObj.provider);
             wallet?.logout();
         }
         $store.commit('login/setLogin', {});

--- a/src/boot/core.ts
+++ b/src/boot/core.ts
@@ -1,9 +1,9 @@
 import { boot } from 'quasar/wrappers';
-import { initAntelope } from 'src/core/wallets/init';
+import { initCore } from 'src/core/wallets/init';
 import { evmSettings, useChainStore } from 'src/core';
 
 export default boot(({ app }) => {
-    initAntelope(app);
+    initCore(app);
 
     const defaultNetwork = Object.keys(evmSettings)[0];
     let network = new URLSearchParams(window.location.search).get('network');

--- a/src/components/AddressMoreInfo.vue
+++ b/src/components/AddressMoreInfo.vue
@@ -33,7 +33,7 @@ const updateData = async () => {
             lastTxn.value = lastTxnQuery.results[0].hash;
             // use total count to offset query and fetch first transaction
             const offset = lastTxnQuery.total_count - 1;
-            const firstTxnQuery = (await indexerApi.get(`address/${props.address}/transactions?limit=1&offset=${offset}`) as TransactionQueryData).data;
+            const firstTxnQuery = (await indexerApi.get(`v1/address/${props.address}/transactions?limit=1&offset=${offset}`) as TransactionQueryData).data;
             firstTxn.value = firstTxnQuery.results[0].hash;
         } else {
             noTrxYet.value = true;

--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -110,6 +110,9 @@ export default defineComponent({
         // initialization of the translated texts
         this.decimalOptions[4].label = this.$t('components.contract_tab.custom');
     },
+    async mounted() {
+        this.updateMissingInputs();
+    },
     computed: {
         ...mapGetters('login', [
             'address',

--- a/src/components/DateField.vue
+++ b/src/components/DateField.vue
@@ -37,7 +37,7 @@ const friendlyDate = computed(() => {
     const showAgeValue = props.forceShowAge === true || (props.forceShowAge === null && showAge.value);
     if (showAgeValue) {
         const difference = Date.now() - props.epoch * 1000;
-        return $t('antelope.words.time_ago', { time: formatTimePeriod(difference / 1000, $t) });
+        return $t('core.words.time_ago', { time: formatTimePeriod(difference / 1000, $t) });
     }
     const timestamp = moment.unix(props.epoch);
     if (props.utc) {

--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -18,7 +18,7 @@ import {
     AccountModel,
     CURRENT_CONTEXT,
     EvmAccountModel,
-    getAntelope,
+    getCore,
     useAccountStore,
     useChainStore,
 } from 'src/core/mocks';
@@ -40,14 +40,14 @@ const browserSupportsMetaMask = ref(true);
 const isBraveBrowser = ref(false);
 const isIOSMobile = ref(false);
 
-const authenticators = computed(() => getAntelope().config.authenticatorsGetter());
+const authenticators = computed(() => getCore().config.authenticatorsGetter());
 
 onMounted(async () => {
     await detectProvider();
     detectMobile();
 
     // On login we must set the address and record the provider
-    getAntelope().events.onLoggedIn.subscribe((account: AccountModel) => {
+    getCore().events.onLoggedIn.subscribe((account: AccountModel) => {
         const evm_account = account as EvmAccountModel;
         const address = evm_account.account;
         const pr_name = evm_account.authenticator.getName();
@@ -67,7 +67,7 @@ onMounted(async () => {
 
     const loginObj = JSON.parse(loginData);
     if (loginObj.type === LOGIN_EVM) {
-        loginWithAntelope(loginObj.provider, loginObj.account);
+        loginWithCore(loginObj.provider, loginObj.account);
     } else if (loginObj.type === LOGIN_NATIVE) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const wallet = authenticators.value.find((a: { getName: () => any; }) => a.getName() === loginObj.provider);
@@ -144,9 +144,9 @@ function getIconForWallet(wallet: { getName: () => string; getStyle: () => { ico
     return wallet.getStyle().icon;
 }
 
-async function loginWithAntelope(name:string, autoLogAccount?: string) {
+async function loginWithCore(name:string, autoLogAccount?: string) {
     const label = CURRENT_CONTEXT;
-    const auth = getAntelope().wallets.getAuthenticator(name);
+    const auth = getCore().wallets.getAuthenticator(name);
     if (!auth) {
         console.error(`${name} authenticator not found`);
         return;
@@ -180,7 +180,7 @@ async function connectMetaMask() {
         return;
     }
 
-    loginWithAntelope(PROVIDER_METAMASK);
+    loginWithCore(PROVIDER_METAMASK);
 }
 
 async function connectBraveWallet() {
@@ -193,11 +193,11 @@ async function connectBraveWallet() {
         });
         return;
     }
-    loginWithAntelope(PROVIDER_BRAVE);
+    loginWithCore(PROVIDER_BRAVE);
 }
 
 function connectWalletConnect() {
-    loginWithAntelope(PROVIDER_WALLET_CONNECT);
+    loginWithCore(PROVIDER_WALLET_CONNECT);
 }
 
 function hideDialog(){

--- a/src/core/chains/EVMChainSettings.ts
+++ b/src/core/chains/EVMChainSettings.ts
@@ -26,7 +26,7 @@ import { ethers } from 'ethers';
 import { toStringNumber } from 'src/core/stores/utils/currency-utils';
 import { dateIsWithinXMinutes } from 'src/core/stores/utils/date-utils';
 import { createTraceFunction } from 'src/core/mocks/FeedbackStore';
-import { getAntelope } from 'src/core';
+import { getCore } from 'src/core';
 import { WEI_PRECISION, PRICE_UPDATE_INTERVAL_IN_MIN } from 'src/core/stores/utils';
 import { BehaviorSubject, filter } from 'rxjs';
 import { TelosEvmApi } from '@telosnetwork/telosevm-js';
@@ -170,7 +170,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
         }
         this.ready = true;
 
-        // this setTimeout is a work arround because we can't call getAntelope() function before it initializes
+        // this setTimeout is a work arround because we can't call getCore() function before it initializes
         setTimeout(() => {
             const timer = setInterval(async () => {
                 try {
@@ -179,7 +179,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
                     clearInterval(timer);
                     console.error('Indexer API not working for this chain:', this.getNetwork(), e);
                 }
-            }, getAntelope().config.indexerHealthCheckInterval);
+            }, getCore().config.indexerHealthCheckInterval);
         }, 1000);
 
         // Update system token price
@@ -243,9 +243,9 @@ export default abstract class EVMChainSettings implements ChainSettings {
         ).subscribe(() => {
             if (!this.indexerHealthWarningShown && !this.isIndexerHealthy()) {
                 this.indexerHealthWarningShown = true;
-                const  ant = getAntelope();
+                const  ant = getCore();
                 ant.config.notifyNeutralMessageHandler(
-                    ant.config.localizationHandler('antelope.chain.indexer_bad_health_warning'),
+                    ant.config.localizationHandler('core.chain.indexer_bad_health_warning'),
                 );
             }
         });
@@ -257,7 +257,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
         } else {
             return (
                 this._indexerHealthState.state.success &&
-                this._indexerHealthState.state.secondsBehind < getAntelope().config.indexerHealthThresholdSeconds
+                this._indexerHealthState.state.secondsBehind < getCore().config.indexerHealthThresholdSeconds
             );
         }
     }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,5 @@
 export * from 'src/core/mocks/AccountStore';
-export * from 'src/core/mocks/AntelopeConfig';
+export * from 'src/core/mocks/CoreConfig';
 export * from 'src/core/mocks/ChainStore';
 export * from 'src/core/mocks/UserStore';
 export * from 'src/core/mocks/ContractStore';

--- a/src/core/mocks/AccountStore.ts
+++ b/src/core/mocks/AccountStore.ts
@@ -3,10 +3,10 @@
 // Mocking AccountStore -----------------------------------
 // useAccountStore().getAccount(this.label).account as addressString;
 import { EVMAuthenticator } from 'src/core/wallets';
-import { AntelopeError, addressString } from 'src/core/types';
+import { CoreError, addressString } from 'src/core/types';
 import { CURRENT_CONTEXT, TeloscanEVMChainSettings, createTraceFunction, useChainStore } from 'src/core/mocks';
 import { BigNumber } from 'ethers'; 'src/core/mocks/FeedbackStore';
-import { getAntelope } from 'src/core/mocks/AntelopeConfig';
+import { getCore } from 'src/core/mocks/CoreConfig';
 import { useFeedbackStore } from 'src/core/mocks';
 import { EvmABI, EvmFunctionParam, Label, TransactionResponse } from 'src/core/types';
 import { subscribeForTransactionReceipt } from 'src/core/wallets/utils/trx-utils';
@@ -60,7 +60,7 @@ class AccountStore {
 
         if (currentAccount) {
             const account = useAccountStore().getAccount(authenticator.label);
-            getAntelope().events.onLoggedIn.next(account);
+            getCore().events.onLoggedIn.next(account);
         }
         return !!currentAccount;
     }
@@ -69,7 +69,7 @@ class AccountStore {
         currentAuthenticator.logout();
         currentAuthenticator = {} as EVMAuthenticator;
         currentAccount = null;
-        getAntelope().events.onLoggedOut.next();
+        getCore().events.onLoggedOut.next();
     }
 
     get loggedAccount() {
@@ -99,12 +99,12 @@ class AccountStore {
         parameters: EvmFunctionParam[],
         value?: BigNumber,
     ): Promise<TransactionResponse>{
-        const ant = getAntelope();
+        const ant = getCore();
         const funcname = 'signCustomTransaction';
         this.trace(funcname, label, contract, abi, parameters, value?.toString());
 
         if (! await this.assertNetworkConnection(label)) {
-            throw new AntelopeError('antelope.evm.error_switch_chain_rejected');
+            throw new CoreError('core.evm.error_switch_chain_rejected');
         }
 
         try {
@@ -157,7 +157,7 @@ class AccountStore {
         if (!await useAccountStore().isConnectedToCorrectNetwork(label)) {
             // eslint-disable-next-line no-async-promise-executor
             return new Promise<boolean>(async (resolve) => {
-                const ant = getAntelope();
+                const ant = getCore();
                 const authenticator = useAccountStore().loggedAccount.authenticator as EVMAuthenticator;
                 try {
                     await authenticator.ensureCorrectChain();
@@ -168,7 +168,7 @@ class AccountStore {
                     }
                 } catch (error) {
                     const message = (error as Error).message;
-                    if (message === 'antelope.evm.error_switch_chain_rejected') {
+                    if (message === 'core.evm.error_switch_chain_rejected') {
                         ant.config.notifyNeutralMessageHandler(message);
                     }
                     resolve(false);

--- a/src/core/mocks/CoreConfig.ts
+++ b/src/core/mocks/CoreConfig.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-// Mocking Antelope and Config -----------------------------------
+// Mocking Core and Config -----------------------------------
 import { EVMAuthenticator } from 'src/core/wallets/authenticators/EVMAuthenticator';
-import { AntelopeError, AntelopeErrorPayload } from 'src/core/types';
+import { CoreError, CoreErrorPayload } from 'src/core/types';
 import { App } from 'vue';
 import { Authenticator, RpcEndpoint } from 'universal-authenticator-library';
 import { Subject } from 'rxjs';
@@ -18,7 +18,7 @@ export interface ComplexMessage {
     text: string,
 }
 
-export class AntelopeWallets {
+export class CoreWallets {
     private authenticators: Map<string, EVMAuthenticator> = new Map();
     private web3Provider: ethers.providers.Web3Provider | null = null;
     private web3ProviderInitializationPromise: Promise<ethers.providers.Web3Provider> | null = null;
@@ -60,7 +60,7 @@ export class AntelopeWallets {
                 return this.web3Provider;
             } catch (e) {
                 this.web3ProviderInitializationPromise = null; // Reset to allow retries.
-                throw new AntelopeError('antelope.evn.error_no_provider');
+                throw new CoreError('core.evn.error_no_provider');
             }
         })();
 
@@ -74,17 +74,16 @@ export class AntelopeWallets {
 
 }
 
-export class AntelopeConfig {
-    transactionError(description: string, error: unknown): AntelopeError {
-        if (error instanceof AntelopeError) {
-            return error as AntelopeError;
+export class CoreConfig {
+    transactionError(description: string, error: unknown): CoreError {
+        if (error instanceof CoreError) {
+            return error as CoreError;
         }
         const msgOrObject = this.errorMessageExtractor(error);
-        // if it matches antelope.*.error_*
         if (typeof msgOrObject === 'string') {
-            return new AntelopeError(msgOrObject, { error });
+            return new CoreError(msgOrObject, { error });
         } else {
-            return new AntelopeError(description, { error: msgOrObject });
+            return new CoreError(description, { error: msgOrObject });
         }
     }
 
@@ -103,8 +102,8 @@ export class AntelopeConfig {
     private __notify_successful_trx_handler: (link: string) => void = alert;
     private __notify_success_message_handler: (message: string, payload?: never) => void = alert;
     private __notify_success_copy_handler: () => void = alert;
-    private __notify_failure_message_handler: (message: string, payload?: AntelopeErrorPayload) => void = alert;
-    private __notify_failure_action_handler: (message: string, payload?: AntelopeErrorPayload) => void = alert;
+    private __notify_failure_message_handler: (message: string, payload?: CoreErrorPayload) => void = alert;
+    private __notify_failure_action_handler: (message: string, payload?: CoreErrorPayload) => void = alert;
     private __notify_disconnected_handler: () => void = alert;
     private __notify_neutral_message_handler: (message: string) => (() => void) = () => (() => void 0);
     private __notify_remember_info_handler: (title: string, message: string | ComplexMessage[],
@@ -117,7 +116,7 @@ export class AntelopeConfig {
     private __localization_handler: (key: string, payload?: Record<string, unknown>) => string = (key: string) => key;
 
     // transaction error handler --
-    private __transaction_error_handler: (err: AntelopeError, trxFailed: string) => void = () => void 0;
+    private __transaction_error_handler: (err: CoreError, trxFailed: string) => void = () => void 0;
 
     // error to string handler --
     private __error_message_extractor: (error: unknown) => object | string | null = (error: unknown) => {
@@ -127,15 +126,15 @@ export class AntelopeConfig {
 
             // high priority generic errors
             switch (evmErr.code) {
-            case 'CALL_EXCEPTION':          return 'antelope.evm.error_call_exception';
-            case 'INSUFFICIENT_FUNDS':      return 'antelope.evm.error_insufficient_funds';
-            case 'MISSING_NEW':             return 'antelope.evm.error_missing_new';
-            case 'NONCE_EXPIRED':           return 'antelope.evm.error_nonce_expired';
-            case 'NUMERIC_FAULT':           return 'antelope.evm.error_numeric_fault';
-            case 'REPLACEMENT_UNDERPRICED': return 'antelope.evm.error_replacement_underpriced';
-            case 'TRANSACTION_REPLACED':    return 'antelope.evm.error_transaction_replaced';
-            case 'USER_REJECTED':           return 'antelope.evm.error_user_rejected';
-            case 'ACTION_REJECTED':         return 'antelope.evm.error_transaction_canceled';
+            case 'CALL_EXCEPTION':          return 'core.evm.error_call_exception';
+            case 'INSUFFICIENT_FUNDS':      return 'core.evm.error_insufficient_funds';
+            case 'MISSING_NEW':             return 'core.evm.error_missing_new';
+            case 'NONCE_EXPIRED':           return 'core.evm.error_nonce_expired';
+            case 'NUMERIC_FAULT':           return 'core.evm.error_numeric_fault';
+            case 'REPLACEMENT_UNDERPRICED': return 'core.evm.error_replacement_underpriced';
+            case 'TRANSACTION_REPLACED':    return 'core.evm.error_transaction_replaced';
+            case 'USER_REJECTED':           return 'core.evm.error_user_rejected';
+            case 'ACTION_REJECTED':         return 'core.evm.error_transaction_canceled';
             }
 
             if (typeof error === 'object') {
@@ -178,7 +177,7 @@ export class AntelopeConfig {
 
             // low priority generic errors
             switch (evmErr.code) {
-            case 'UNPREDICTABLE_GAS_LIMIT': return 'antelope.evm.error_unpredictable_gas_limit';
+            case 'UNPREDICTABLE_GAS_LIMIT': return 'core.evm.error_unpredictable_gas_limit';
             }
 
             if (typeof error === 'string') {
@@ -319,11 +318,11 @@ export class AntelopeConfig {
         this.__notify_success_copy_handler = handler;
     }
 
-    public setNotifyFailureMessage(handler: (message: string, payload?: AntelopeErrorPayload) => void) {
+    public setNotifyFailureMessage(handler: (message: string, payload?: CoreErrorPayload) => void) {
         this.__notify_failure_message_handler = handler;
     }
 
-    public setNotifyFailureWithAction(handler: (message: string, payload?: AntelopeErrorPayload) => void) {
+    public setNotifyFailureWithAction(handler: (message: string, payload?: CoreErrorPayload) => void) {
         this.__notify_failure_action_handler = handler;
     }
 
@@ -355,7 +354,7 @@ export class AntelopeConfig {
     }
 
     // setting transaction error handler --
-    public setTransactionErrorHandler(handler: (err: AntelopeError, trxFailed: string) => void) {
+    public setTransactionErrorHandler(handler: (err: CoreError, trxFailed: string) => void) {
         this.__transaction_error_handler = handler;
     }
 
@@ -366,14 +365,14 @@ export class AntelopeConfig {
 
 }
 
-const config = new AntelopeConfig();
-const wallets = new AntelopeWallets();
+const config = new CoreConfig();
+const wallets = new CoreWallets();
 const events = {
     onLoggedIn: new Subject<AccountModel>(),
     onLoggedOut: new Subject<void>(),
     onNetworkChanged: new Subject<{label:string, chain:ChainModel}>(),
 };
-const Antelope = {
+const Core = {
     config,
     wallets,
     events,
@@ -382,9 +381,9 @@ const Antelope = {
 // each time the user changes the network,
 // we need to reset the current web3 provider instance
 events.onNetworkChanged.subscribe(() => {
-    Antelope.wallets.resetWeb3Provider();
+    Core.wallets.resetWeb3Provider();
 });
 
-export const getAntelope = () => Antelope;
+export const getCore = () => Core;
 // ----------------------------------------------------------------
 

--- a/src/core/mocks/EVMStore.ts
+++ b/src/core/mocks/EVMStore.ts
@@ -5,7 +5,7 @@ import { ethers } from 'ethers';
 import { EVMAuthenticator, InjectedProviderAuth } from 'src/core/wallets';
 import { createTraceFunction } from 'src/core/mocks/FeedbackStore';
 import { TeloscanEVMChainSettings, useChainStore, useFeedbackStore, useAccountStore } from 'src/core/mocks';
-import { AntelopeError, EthereumProvider, ExceptionError } from 'src/core/types';
+import { CoreError, EthereumProvider, ExceptionError } from 'src/core/types';
 import { RpcEndpoint } from 'universal-authenticator-library';
 
 class EVMStore {
@@ -30,7 +30,7 @@ class EVMStore {
             for (const method of methods) {
                 if (typeof candidate[method] !== 'function') {
                     console.warn(`MetamaskAuth.getProvider: method ${method} not found`);
-                    throw new AntelopeError('antelope.evm.error_invalid_provider');
+                    throw new CoreError('core.evm.error_invalid_provider');
                 }
             }
 
@@ -85,7 +85,7 @@ class EVMStore {
             const chainIdParam = `0x${chainId.toString(16)}`;
             if (!provider.request) {
                 useFeedbackStore().unsetLoading('evm.switchChainInjected');
-                throw new AntelopeError('antelope.evm.error_support_provider_request');
+                throw new CoreError('core.evm.error_support_provider_request');
             }
             try {
                 await provider.request({
@@ -104,7 +104,7 @@ class EVMStore {
                     const rpcUrl = `${p.protocol}://${p.host}:${p.port}${p.path ?? ''}`;
                     try {
                         if (!provider.request) {
-                            throw new AntelopeError('antelope.evm.error_support_provider_request');
+                            throw new CoreError('core.evm.error_support_provider_request');
                         }
                         const payload = {
                             method: 'wallet_addEthereumChain',
@@ -125,24 +125,24 @@ class EVMStore {
                         return true;
                     } catch (e) {
                         if ((e as unknown as ExceptionError).code === 4001) {
-                            throw new AntelopeError('antelope.evm.error_add_chain_rejected');
+                            throw new CoreError('core.evm.error_add_chain_rejected');
                         } else {
                             console.error('Error:', e);
-                            throw new AntelopeError('antelope.evm.error_add_chain');
+                            throw new CoreError('core.evm.error_add_chain');
                         }
                     }
                 } else if ((error as unknown as ExceptionError).code === 4001) {
-                    throw new AntelopeError('antelope.evm.error_switch_chain_rejected');
+                    throw new CoreError('core.evm.error_switch_chain_rejected');
                 } else {
                     console.error('Error:', error);
-                    throw new AntelopeError('antelope.evm.error_switch_chain');
+                    throw new CoreError('core.evm.error_switch_chain');
                 }
             } finally {
                 useFeedbackStore().unsetLoading('evm.switchChainInjected');
             }
         } else {
             useFeedbackStore().unsetLoading('evm.switchChainInjected');
-            throw new AntelopeError('antelope.evm.error_no_provider');
+            throw new CoreError('core.evm.error_no_provider');
         }
     }
 

--- a/src/core/mocks/FeedbackStore.ts
+++ b/src/core/mocks/FeedbackStore.ts
@@ -13,7 +13,7 @@ export const createTraceFunction = (store_name: string) => function(action: stri
 
 
 // only if we are NOT in production mode search in the url for the trace flag
-// to turn on the Antelope trace mode
+// to turn on the core trace mode
 let trace = false;
 if (process.env.NODE_ENV !== 'production') {
     const urlParams = new URLSearchParams(window.location.search);

--- a/src/core/mocks/index.ts
+++ b/src/core/mocks/index.ts
@@ -1,6 +1,6 @@
 export * from 'src/core/mocks/FeedbackStore';
 export * from 'src/core/mocks/AccountStore';
-export * from 'src/core/mocks/AntelopeConfig';
+export * from 'src/core/mocks/CoreConfig';
 export * from 'src/core/mocks/ChainStore';
 export * from 'src/core/mocks/ContractStore';
 export * from 'src/core/mocks/EVMStore';

--- a/src/core/stores/utils/contracts/EvmContract.ts
+++ b/src/core/stores/utils/contracts/EvmContract.ts
@@ -1,7 +1,7 @@
 import { BigNumber, ContractInterface, ethers } from 'ethers';
 import { markRaw } from 'vue';
 import {
-    AntelopeError, EvmContractCalldata,
+    CoreError, EvmContractCalldata,
     EvmABI,
     EvmContractCreationInfo,
     EvmContractConstructorData,
@@ -145,7 +145,7 @@ export default class EvmContract {
 
     async getContractInstance() {
         if (!this.abi){
-            throw new AntelopeError('antelope.utils.error_contract_instance');
+            throw new CoreError('core.utils.error_contract_instance');
         }
 
         if (this._contractInstance) {
@@ -183,7 +183,7 @@ export default class EvmContract {
                 console.error(`Failed to parse transaction data ${data} using abi for ${this.address}`);
             }
         }
-        throw new AntelopeError('antelope.utils.error_parsing_transaction');
+        throw new CoreError('core.utils.error_parsing_transaction');
     }
 
     async parseLogs(logs: EvmLogs): Promise<EvmFormatedLog[]> {
@@ -239,10 +239,10 @@ export default class EvmContract {
                 const parsedLog:ethers.utils.LogDescription = eventIface.parseLog(log);
                 return this.formatLog(log, parsedLog);
             } catch(e) {
-                throw new AntelopeError('antelope.utils.error_parsing_log_event', log);
+                throw new CoreError('core.utils.error_parsing_log_event', log);
             }
         } else {
-            throw new AntelopeError('antelope.utils.error_parsing_log_event', log);
+            throw new CoreError('core.utils.error_parsing_log_event', log);
         }
     }
 }

--- a/src/core/stores/utils/contracts/EvmContractFactory.ts
+++ b/src/core/stores/utils/contracts/EvmContractFactory.ts
@@ -1,11 +1,11 @@
 import { erc1155Abi, erc20Abi, erc721Abi } from 'src/core/stores/utils/abi';
 import EvmContract from 'src/core/stores/utils/contracts/EvmContract';
-import { AntelopeError, EvmContractCalldata, EvmContractMetadata, EvmContractFactoryData } from 'src/core/types';
+import { CoreError, EvmContractCalldata, EvmContractMetadata, EvmContractFactoryData } from 'src/core/types';
 
 export default class EvmContractFactory {
     buildContract(data: EvmContractFactoryData): EvmContract {
         if (!data || !data.address) {
-            throw new AntelopeError('antelope.contracts.contract_data_required');
+            throw new CoreError('core.contracts.contract_data_required');
         }
 
         let verified = false;

--- a/src/core/stores/utils/trx-utils.ts
+++ b/src/core/stores/utils/trx-utils.ts
@@ -1,6 +1,6 @@
 import { usePlatformStore } from 'src/core';
 import { ethers } from 'ethers';
-import { AntelopeError, TransactionResponse } from 'src/core/types';
+import { CoreError, TransactionResponse } from 'src/core/types';
 import { AccountModel, EVMAuthenticator } from 'src/core/wallets';
 
 
@@ -9,7 +9,7 @@ export async function subscribeForTransactionReceipt(account: AccountModel, resp
     receipt: ethers.providers.TransactionReceipt;
 }> {
     if (account.isNative) {
-        throw new AntelopeError('Not implemented yet for native');
+        throw new CoreError('Not implemented yet for native');
     } else {
         const authenticator = account.authenticator as EVMAuthenticator;
         const provider = await authenticator.web3Provider();
@@ -28,7 +28,7 @@ export async function subscribeForTransactionReceipt(account: AccountModel, resp
                 response.wait = async () => Promise.resolve({} as ethers.providers.TransactionReceipt);
                 return result;
             } else {
-                throw new AntelopeError('antelope.evm.error_no_provider');
+                throw new CoreError('core.evm.error_no_provider');
             }
         }
     }

--- a/src/core/types/CoreError.ts
+++ b/src/core/types/CoreError.ts
@@ -1,9 +1,9 @@
-export interface AntelopeErrorPayload {
+export interface CoreErrorPayload {
     [key:string]: unknown
 }
 
-export class AntelopeError extends Error {
-    public payload?: AntelopeErrorPayload;
+export class CoreError extends Error {
+    public payload?: CoreErrorPayload;
     constructor(
         message: string | undefined,
         public _payload?: unknown,

--- a/src/core/types/TokenClass.ts
+++ b/src/core/types/TokenClass.ts
@@ -52,7 +52,7 @@ export interface TokenSourceInfo {
     logoURI?: string;                      // Token logo uri (as used in EVM)
     metadata?: string;                     // Token contract metadata (as used in EVM)
     isSystem: boolean;                     // True if the token is the main system token
-    isNative: boolean;                     // True if the token is a Antelope native blockchain token (false for EVM)
+    isNative: boolean;                     // True if the token is a Core native blockchain token (false for EVM)
     amount?: number | string;              // posible balance amount
     balance?: string;                      // posible balance amount
     fullBalance?: string;                  // posible balance amount

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -1,7 +1,6 @@
-// interfaces for antelope
 export * from 'src/core/types/ABIv1';
 export * from 'src/core/types/Actions';
-export * from 'src/core/types/AntelopeError';
+export * from 'src/core/types/CoreError';
 export * from 'src/core/types/Api';
 export * from 'src/core/types/ChainInfo';
 export * from 'src/core/types/ChainSettings';
@@ -24,10 +23,4 @@ export * from 'src/core/types/Providers';
 export * from 'src/core/types/Theme';
 export * from 'src/core/types/TokenClass';
 export * from 'src/core/types/TransactionV1';
-
-
-// classes for antelope
-export * from 'src/core/types/AntelopeError';
-
-// interfaces for antelope evm-abi
 export * from 'src/core/wallets/utils/abi';

--- a/src/core/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/core/wallets/authenticators/EVMAuthenticator.ts
@@ -5,13 +5,13 @@
 import { SendTransactionResult, WriteContractResult } from '@wagmi/core';
 import { BigNumber, ethers } from 'ethers';
 import { createTraceFunction } from 'src/core/mocks/FeedbackStore';
-import { CURRENT_CONTEXT, getAntelope, useAccountStore } from 'src/core/mocks';
+import { CURRENT_CONTEXT, getCore, useAccountStore } from 'src/core/mocks';
 import { TeloscanEVMChainSettings } from 'src/core/mocks';
 import { useChainStore } from 'src/core/mocks';
 import { useEVMStore } from 'src/core/mocks';
 import { isTracingAll, useFeedbackStore } from 'src/core/mocks/FeedbackStore';
 import { usePlatformStore } from 'src/core/mocks';
-import { AntelopeError, EvmABI, EvmFunctionParam, EvmTransactionResponse, ExceptionError, TokenClass, addressString } from 'src/core/types';
+import { CoreError, EvmABI, EvmFunctionParam, EvmTransactionResponse, ExceptionError, TokenClass, addressString } from 'src/core/types';
 
 export abstract class EVMAuthenticator {
 
@@ -74,7 +74,7 @@ export abstract class EVMAuthenticator {
                 return accounts[0] as addressString;
             } else {
                 if (!checkProvider.provider.request) {
-                    throw new AntelopeError('antelope.evm.error_support_provider_request');
+                    throw new CoreError('core.evm.error_support_provider_request');
                 }
                 const accessGranted = await checkProvider.provider.request({ method: 'eth_requestAccounts' });
                 if (accessGranted.length < 1) {
@@ -84,10 +84,10 @@ export abstract class EVMAuthenticator {
             }
         } catch (error) {
             if ((error as unknown as ExceptionError).code === 4001) {
-                throw new AntelopeError('antelope.evm.error_connect_rejected');
+                throw new CoreError('core.evm.error_connect_rejected');
             } else {
                 console.error('Error:', error);
-                throw new AntelopeError('antelope.evm.error_login');
+                throw new CoreError('core.evm.error_login');
             }
         }
     }
@@ -102,10 +102,10 @@ export abstract class EVMAuthenticator {
             return account as addressString;
         } catch (error) {
             if ((error as unknown as ExceptionError).code === 4001) {
-                throw new AntelopeError('antelope.evm.error_connect_rejected');
+                throw new CoreError('core.evm.error_connect_rejected');
             } else {
                 console.error('Error:', error);
-                throw new AntelopeError('antelope.evm.error_login');
+                throw new CoreError('core.evm.error_login');
             }
         }
     }
@@ -119,10 +119,10 @@ export abstract class EVMAuthenticator {
             const showSwitchNotification = !(await this.isConnectedToCorrectChain());
             return useEVMStore().ensureCorrectChain(this).then((result) => {
                 if (showSwitchNotification) {
-                    const ant = getAntelope();
+                    const ant = getCore();
                     const networkName = useChainStore().getChain(this.label).settings.getDisplay();
                     ant.config.notifyNeutralMessageHandler(
-                        ant.config.localizationHandler('antelope.wallets.network_switch_success', { networkName }),
+                        ant.config.localizationHandler('core.wallets.network_switch_success', { networkName }),
                     );
                 }
                 return result;

--- a/src/core/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/core/wallets/authenticators/InjectedProviderAuth.ts
@@ -6,7 +6,7 @@ import { BehaviorSubject } from 'rxjs';
 import { map, filter } from 'rxjs/operators';
 import { useEVMStore, useFeedbackStore } from 'src/core';
 import {
-    AntelopeError,
+    CoreError,
     EthereumProvider,
     EvmABI,
     EvmFunctionParam,
@@ -47,20 +47,20 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
                 if (provider) {
                     resolve(provider);
                 } else {
-                    reject(new AntelopeError('antelope.evm.error_no_provider'));
+                    reject(new CoreError('core.evm.error_no_provider'));
                 }
             });
         });
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private handleCatchError(error: any): AntelopeError {
+    private handleCatchError(error: any): CoreError {
         if ('ACTION_REJECTED' === ((error as {code:string}).code)) {
-            return new AntelopeError('antelope.evm.error_transaction_canceled');
+            return new CoreError('core.evm.error_transaction_canceled');
         } else {
             // unknown error we print on console
             console.error(error);
-            return new AntelopeError('antelope.evm.error_send_transaction', { error });
+            return new CoreError('core.evm.error_send_transaction', { error });
         }
     }
 
@@ -171,7 +171,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
             if (
                 trackAnalyticsEvents &&
                 isTelos &&
-                error.message !== 'antelope.evm.error_connect_rejected'
+                error.message !== 'core.evm.error_connect_rejected'
             ) {
                 let failedLoginEventName = '';
 
@@ -205,7 +205,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
         if (provider) {
             return provider.getBalance(address);
         } else {
-            throw new AntelopeError('antelope.evm.error_no_provider');
+            throw new CoreError('core.evm.error_no_provider');
         }
     }
 
@@ -218,7 +218,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
                 const balance = await erc20Contract.balanceOf(address);
                 return balance;
             } else {
-                throw new AntelopeError('antelope.evm.error_no_provider');
+                throw new CoreError('core.evm.error_no_provider');
             }
         } catch (e) {
             console.error('getERC20TokenBalance', e, address, token);

--- a/src/core/wallets/authenticators/OreIdAuth.ts
+++ b/src/core/wallets/authenticators/OreIdAuth.ts
@@ -14,7 +14,7 @@ import {
 } from 'src/core/types';
 import { EVMAuthenticator } from 'src/core/wallets';
 import {
-    AntelopeError,
+    CoreError,
     TokenClass,
     addressString,
     EvmTransactionResponse,
@@ -79,7 +79,7 @@ export class OreIdAuth extends EVMAuthenticator {
         case ChainNetwork.TelosEvmMain:
             return 'telos-evm';
         default:
-            throw new AntelopeError('antelope.evm.error_invalid_chain_network');
+            throw new CoreError('core.evm.error_invalid_chain_network');
         }
     }
 
@@ -91,7 +91,7 @@ export class OreIdAuth extends EVMAuthenticator {
         case 'telos-evm':
             return ChainNetwork.TelosEvmMain;
         default:
-            throw new AntelopeError('antelope.evm.error_invalid_chain_network');
+            throw new CoreError('core.evm.error_invalid_chain_network');
         }
     }
 
@@ -148,7 +148,7 @@ export class OreIdAuth extends EVMAuthenticator {
             this.trace('login', 'trackAnalyticsEvent -> login failed', this.getName(), TELOS_ANALYTICS_EVENT_NAMES.loginFailedOreId);
             chainSettings.trackAnalyticsEvent(TELOS_ANALYTICS_EVENT_NAMES.loginFailedOreId);
 
-            throw new AntelopeError('antelope.wallets.error_oreid_no_chain_account', {
+            throw new CoreError('core.wallets.error_oreid_no_chain_account', {
                 networkName,
                 appName,
             });
@@ -184,7 +184,7 @@ export class OreIdAuth extends EVMAuthenticator {
             if (provider) {
                 return provider.getBalance(address);
             } else {
-                throw new AntelopeError('antelope.evm.error_no_provider');
+                throw new CoreError('core.evm.error_no_provider');
             }
         } catch (e) {
             console.error('getSystemTokenBalance', e, address);
@@ -201,7 +201,7 @@ export class OreIdAuth extends EVMAuthenticator {
                 const balance = await erc20Contract.balanceOf(address);
                 return balance;
             } else {
-                throw new AntelopeError('antelope.evm.error_no_provider');
+                throw new CoreError('core.evm.error_no_provider');
             }
         } catch (e) {
             console.error('getERC20TokenBalance', e, address, token);
@@ -219,12 +219,12 @@ export class OreIdAuth extends EVMAuthenticator {
     checkIntegrity(): boolean {
         if (!this.userChainAccount) {
             console.error('Inconsistency error: userChainAccount is null');
-            throw new AntelopeError('antelope.evm.error_no_provider');
+            throw new CoreError('core.evm.error_no_provider');
         }
 
         if (!oreId) {
             console.error('Inconsistency error: oreId is null');
-            throw new AntelopeError('antelope.evm.error_no_provider');
+            throw new CoreError('core.evm.error_no_provider');
         }
 
         return true;

--- a/src/core/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/core/wallets/authenticators/WalletConnectAuth.ts
@@ -27,7 +27,7 @@ import { useContractStore } from 'src/core';
 import { useFeedbackStore } from 'src/core';
 import { usePlatformStore } from 'src/core';
 import {
-    AntelopeError,
+    CoreError,
     EvmABI,
     EvmFunctionParam,
     TokenClass,
@@ -141,7 +141,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
                 const chainSettings = this.getChainSettings();
                 chainSettings.trackAnalyticsEvent(TELOS_ANALYTICS_EVENT_NAMES.loginFailedWalletConnect);
             }
-            throw new AntelopeError('antelope.evm.error_login');
+            throw new CoreError('core.evm.error_login');
         } finally {
             useFeedbackStore().unsetLoading(`${this.getName()}.login`);
         }
@@ -287,9 +287,9 @@ export class WalletConnectAuth extends EVMAuthenticator {
     async transferTokens(token: TokenClass, amount: BigNumber, to: addressString): Promise<SendTransactionResult | WriteContractResult> {
         this.trace('transferTokens', token, amount, to);
         if (!this.sendConfig) {
-            throw new AntelopeError(token.isSystem ?
-                'antelope.wallets.error_system_token_transfer_config' :
-                'antelope.wallets.error_token_transfer_config',
+            throw new CoreError(token.isSystem ?
+                'core.wallets.error_system_token_transfer_config' :
+                'core.wallets.error_token_transfer_config',
             );
         } else {
             if (token.isSystem) {
@@ -493,7 +493,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
             const injected = new InjectedConnector();
             const provider = toRaw(await injected.getProvider());
             if (!provider) {
-                throw new AntelopeError('antelope.evm.error_no_provider');
+                throw new CoreError('core.evm.error_no_provider');
             }
             resolve(provider as unknown as ethers.providers.ExternalProvider);
         });

--- a/src/core/wallets/init.ts
+++ b/src/core/wallets/init.ts
@@ -5,14 +5,14 @@ import { Web3ModalConfig } from '@web3modal/html';
 import { MetamaskAuth, SafePalAuth, WalletConnectAuth, BraveAuth, useChainStore } from 'src/core/wallets';
 import { configureChains, createConfig } from '@wagmi/core';
 import { telos, telosTestnet } from '@wagmi/core/chains';
-import { getAntelope } from 'src/core/mocks/AntelopeConfig';
+import { getCore } from 'src/core/mocks/CoreConfig';
 import { App } from 'vue';
-import { AntelopeError } from 'src/core/types';
+import { CoreError } from 'src/core/types';
 
 /**
  * This function is used to register the EVMAuthenticators that will be used by the app.
  */
-export function initAntelope(app: App) {
+export function initCore(app: App) {
 
     const projectId = process.env.PROJECT_ID || '14ec76c44bae7d461fa0f5fd5f8a9da1';
     const chains = [telos, telosTestnet];
@@ -38,7 +38,7 @@ export function initAntelope(app: App) {
     const explorerExcludedWalletIds = 'ALL' as const; // Web3Modal option excludes all but recomended
     const wagmiOptions: Web3ModalConfig = { projectId, explorerRecommendedWalletIds, explorerExcludedWalletIds };
 
-    const ant = getAntelope();
+    const ant = getCore();
     ant.config.init(app);
 
     // settting notification handlers --
@@ -62,9 +62,9 @@ export function initAntelope(app: App) {
 
     // setting transaction error handler --
     ant.config.setTransactionErrorHandler((err: object) => {
-        if (err instanceof AntelopeError) {
-            const evmErr = err as AntelopeError;
-            if (evmErr.message === 'antelope.evm.error_transaction_canceled') {
+        if (err instanceof CoreError) {
+            const evmErr = err as CoreError;
+            if (evmErr.message === 'core.evm.error_transaction_canceled') {
                 ant.config.notifyNeutralMessageHandler(ant.config.localizationHandler(evmErr.message));
             } else {
                 ant.config.notifyFailureMessage(ant.config.localizationHandler(evmErr.message), evmErr.payload);

--- a/src/core/wallets/utils/contracts/EvmContract.ts
+++ b/src/core/wallets/utils/contracts/EvmContract.ts
@@ -2,7 +2,7 @@
 import { ContractInterface, ethers } from 'ethers';
 import { markRaw } from 'vue';
 import {
-    AntelopeError, EvmContractCalldata,
+    CoreError, EvmContractCalldata,
     EvmABI,
     EvmContractCreationInfo,
     EvmContractConstructorData,
@@ -136,7 +136,7 @@ export default class EvmContract {
 
     async getContractInstance() {
         if (!this.abi){
-            throw new AntelopeError('antelope.utils.error_contract_instance');
+            throw new CoreError('core.utils.error_contract_instance');
         }
         const signer = await this._manager?.getSigner();
 
@@ -161,7 +161,7 @@ export default class EvmContract {
                 console.error(`Failed to parse transaction data ${data} using abi for ${this.address}`);
             }
         }
-        throw new AntelopeError('antelope.utils.error_parsing_transaction');
+        throw new CoreError('core.utils.error_parsing_transaction');
     }
 
     async parseLogs(logs: EvmLogs): Promise<EvmFormatedLog[]> {
@@ -217,10 +217,10 @@ export default class EvmContract {
                 const parsedLog:ethers.utils.LogDescription = eventIface.parseLog(log);
                 return this.formatLog(log, parsedLog);
             } catch(e) {
-                throw new AntelopeError('antelope.utils.error_parsing_log_event', log);
+                throw new CoreError('core.utils.error_parsing_log_event', log);
             }
         } else {
-            throw new AntelopeError('antelope.utils.error_parsing_log_event', log);
+            throw new CoreError('core.utils.error_parsing_log_event', log);
         }
     }
 }

--- a/src/core/wallets/utils/contracts/EvmContractFactory.ts
+++ b/src/core/wallets/utils/contracts/EvmContractFactory.ts
@@ -1,12 +1,12 @@
 /* eslint-disable max-len */
 import { erc1155Abi, erc20Abi, erc721Abi } from 'src/core/wallets/utils/abi';
 import EvmContract from 'src/core/wallets/utils/contracts/EvmContract';
-import { AntelopeError, EvmContractCalldata, EvmContractMetadata, EvmContractFactoryData } from 'src/core/types';
+import { CoreError, EvmContractCalldata, EvmContractMetadata, EvmContractFactoryData } from 'src/core/types';
 
 export default class EvmContractFactory {
     buildContract(data: EvmContractFactoryData): EvmContract {
         if (!data || !data.address) {
-            throw new AntelopeError('antelope.contracts.contract_data_required');
+            throw new CoreError('core.contracts.contract_data_required');
         }
 
         let verified = false;

--- a/src/core/wallets/utils/trx-utils.ts
+++ b/src/core/wallets/utils/trx-utils.ts
@@ -1,7 +1,7 @@
 import { usePlatformStore } from 'src/core';
 import { ethers } from 'ethers';
 import { AccountModel } from 'src/core/mocks';
-import { AntelopeError, TransactionResponse } from 'src/core/types';
+import { CoreError, TransactionResponse } from 'src/core/types';
 import { EVMAuthenticator } from 'src/core/wallets';
 
 
@@ -10,7 +10,7 @@ export async function subscribeForTransactionReceipt(account: AccountModel, resp
     receipt: ethers.providers.TransactionReceipt;
 }> {
     if (account.isNative) {
-        throw new AntelopeError('Not implemented yet for native');
+        throw new CoreError('Not implemented yet for native');
     } else {
         const authenticator = account.authenticator as EVMAuthenticator;
         const provider = await authenticator.web3Provider();
@@ -29,7 +29,7 @@ export async function subscribeForTransactionReceipt(account: AccountModel, resp
                 response.wait = async () => Promise.resolve({} as ethers.providers.TransactionReceipt);
                 return result;
             } else {
-                throw new AntelopeError('antelope.evm.error_no_provider');
+                throw new CoreError('core.evm.error_no_provider');
             }
         }
     }

--- a/src/i18n/de-de/index.js
+++ b/src/i18n/de-de/index.js
@@ -698,7 +698,7 @@ export default {
         neutral_message_custom_call: 'Aufrufen von <b>{name}</b> mit <b>{params} Parametern</b>',
         neutral_message_custom_call_send: 'Aufrufen von <b>{name}</b> mit <b>{params} Parametern</b> und Senden von <b>{quantity} {symbol}</b>',
     },
-    antelope: {
+    core: {
         contracts: {
             invalid_contract: 'Vertrag oder Vertrag ABI fehlt',
             contract_data_required: 'Vertragsdaten fehlen',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -704,7 +704,7 @@ export default {
         neutral_message_custom_call: 'calling <b>{name}</b> with <b>{params} parameters</b>',
         neutral_message_custom_call_send: 'calling <b>{name}</b> with <b>{params} parameters</b>, sending <b>{quantity} {symbol}</b></b>',
     },
-    antelope: {
+    core: {
         contracts: {
             invalid_contract: 'Contract or contract ABI missing',
             contract_data_required: 'Contract data missing',

--- a/src/i18n/es-es/index.js
+++ b/src/i18n/es-es/index.js
@@ -698,7 +698,7 @@ export default {
         neutral_message_custom_call: 'llamando a <b>{name}</b> con <b>{params} parámetros</b>',
         neutral_message_custom_call_send: 'llamando a <b>{name}</b> con <b>{params} parámetros</b> y enviando <b>{quantity} {symbol}</b>',
     },
-    antelope: {
+    core: {
         contracts: {
             invalid_contract: 'Contrato o ABI del contrato faltante',
             contract_data_required: 'Datos del contrato faltantes',

--- a/src/i18n/fr-fr/index.js
+++ b/src/i18n/fr-fr/index.js
@@ -698,7 +698,7 @@ export default {
         neutral_message_custom_call: 'Appel à <b>{name}</b> avec <b>{params} paramètres</b>',
         neutral_message_custom_call_send: 'Appel à <b>{name}</b> avec <b>{params} paramètres</b> et envoi de <b>{quantity} {symbol}</b>',
     },
-    antelope: {
+    core: {
         contracts: {
             invalid_contract: 'Contrat ou ABI du contrat manquant',
             contract_data_required: 'Données du contrat manquantes',

--- a/src/i18n/pt-br/index.js
+++ b/src/i18n/pt-br/index.js
@@ -698,7 +698,7 @@ export default {
         neutral_message_custom_call: 'Chamando <b>{name}</b> com <b>{params} parâmetros</b>',
         neutral_message_custom_call_send: 'Chamando <b>{name}</b> com <b>{params} parâmetros</b> e enviando <b>{quantity} {symbol}</b>',
     },
-    antelope: {
+    core: {
         contracts: {
             invalid_contract: 'Contrato ou ABI do contrato ausente',
             contract_data_required: 'Dados do contrato ausentes',

--- a/src/lib/contract/ContractManager.js
+++ b/src/lib/contract/ContractManager.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { getTopicHash } from 'src/lib/utils';
 import { ERC1155_TRANSFER_SIGNATURE, TRANSFER_SIGNATURES } from 'src/lib/abi/signature/transfer_signatures.js';
 import { erc1155Abi, erc721MetadataAbi } from 'src/lib/abi';
-import { getAntelope, useChainStore } from 'src/core';
+import { getCore, useChainStore } from 'src/core';
 const tokenList = 'https://raw.githubusercontent.com/telosnetwork/token-list/main/telosevm.tokenlist.json';
 const systemContractList =
     'https://raw.githubusercontent.com/telosnetwork/token-list/main/telosevm.systemcontractlist.json';
@@ -100,7 +100,7 @@ export default class ContractManager {
     }
 
     async getEthersProvider() {
-        return getAntelope().wallets.getWeb3Provider();
+        return getCore().wallets.getWeb3Provider();
     }
     async getTransfers(raw) {
         if(!raw.logs || raw.logs?.length === 0){

--- a/src/lib/contract/ContractManager.js
+++ b/src/lib/contract/ContractManager.js
@@ -99,7 +99,7 @@ export default class ContractManager {
         }
     }
 
-    getEthersProvider() {
+    async getEthersProvider() {
         return getAntelope().wallets.getWeb3Provider();
     }
     async getTransfers(raw) {
@@ -300,13 +300,17 @@ export default class ContractManager {
         return this.tokenList;
     }
 
-    getContractInstance(contract, provider) {
+    async getContractInstance(contract, provider) {
         if (!contract.abi){
             console.error('Cannot create contract instance without ABI !');
             return false;
         }
 
-        return new ethers.Contract(contract.address, contract.abi, provider ? provider : this.getEthersProvider());
+        const _provider = provider ? provider : await this.getEthersProvider();
+        console.assert(_provider, 'No provider available to create contract instance');
+        console.assert(_provider.connection, 'Provider connection not available to create contract instance');
+        console.assert(typeof _provider.connection.url === 'string', 'Provider connection url not available to create contract instance');
+        return new ethers.Contract(contract.address, contract.abi, _provider);
     }
     async getCachedContract(address) {
         if (address === null || typeof address !== 'string') {
@@ -386,6 +390,6 @@ export default class ContractManager {
     }
 
     async getContractFromAbi(address, abi){
-        return new ethers.Contract(address, abi, this.getEthersProvider());
+        return new ethers.Contract(address, abi, await this.getEthersProvider());
     }
 }

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -13,16 +13,16 @@ export function formatTimePeriod(seconds: number, $t: (key: string) => string) {
 
     if (seconds < 60) {
         quantity = Math.round(seconds);
-        unit = quantity === 1 ? $t('antelope.words.second') : $t('antelope.words.seconds');
+        unit = quantity === 1 ? $t('core.words.second') : $t('core.words.seconds');
     } else if (seconds < HOUR_SECONDS) {
         quantity = Math.round(seconds / 60);
-        unit = quantity === 1 ? $t('antelope.words.minute') : $t('antelope.words.minutes');
+        unit = quantity === 1 ? $t('core.words.minute') : $t('core.words.minutes');
     } else if (seconds < DAY_SECONDS) {
         quantity = Math.round(seconds / HOUR_SECONDS);
-        unit = quantity === 1 ? $t('antelope.words.hour') : $t('antelope.words.hours');
+        unit = quantity === 1 ? $t('core.words.hour') : $t('core.words.hours');
     } else {
         quantity = Math.round(seconds / DAY_SECONDS);
-        unit = quantity === 1 ? $t('antelope.words.day') : $t('antelope.words.days');
+        unit = quantity === 1 ? $t('core.words.day') : $t('core.words.days');
     }
 
     return `${quantity} ${unit}`;


### PR DESCRIPTION
# Fixes #897

## Description
There was an issue with the simple read functions on contracts that caused the query button to remain disabled when no parameters were required. This PR resolves that problem, allowing you to use the query button for no-parameter read functions on contracts.

Additionally, this PR completely removes the Antelope name (the old name for the library we were building) and replaces it with the term 'core.'

## Test scenarios
1. Go to this [contract page](https://deploy-preview-898--dev-mainnet-teloscan.netlify.app/address/0xc96afc666A4195366a46E4ca8C4f10f3C39Ee363?tab=contract&subtab=read)
2. Change to read tab
3. open any function expansion-item component
4. press query button
5. You should get the result displayed as shown in the screen capture.

![image](https://github.com/user-attachments/assets/1dde96ee-180c-48fa-bc68-4fc093e12d9f)
