### PR TITLE
#902 | in low resolutions the switch network component uses the old buttons

### DIFF
--- a/src/components/header/AppHeaderLinks.vue
+++ b/src/components/header/AppHeaderLinks.vue
@@ -4,15 +4,11 @@ import { useRoute, useRouter } from 'vue-router';
 import { useQuasar } from 'quasar';
 import { useI18n } from 'vue-i18n';
 
-import {
-    TELOSCAN_MAINNET_URL,
-    TELOSCAN_TESTNET_URL,
-} from 'src/lib/chain-utils';
-
 import LanguageSwitcherModal from 'components/header/LanguageSwitcherModal.vue';
 import OutlineButton from 'components/OutlineButton.vue';
 import { useChainStore } from 'src/core';
 import { HeaderMenuEntry } from 'src/core/types';
+import { chains, multichainSelectedNetwork, switchChain } from 'src/lib/multichain-utils';
 
 const $route = useRoute();
 const $router = useRouter();
@@ -23,17 +19,6 @@ defineProps<{
     menuVisibleMobile: boolean;
 }>();
 const emit = defineEmits(['close-menu']);
-
-const networksMenuItems = {
-    mainnet: [{
-        url: TELOSCAN_MAINNET_URL,
-        label: 'Telos Mainnet',
-    }],
-    testnet: [{
-        url: TELOSCAN_TESTNET_URL,
-        label: 'Telos Testnet',
-    }],
-};
 
 const blockchainMenuExpandedMobile = ref(false);
 const developersMenuExpandedMobile = ref(false);
@@ -104,28 +89,6 @@ function closeAllMenus() {
 function toggleDarkMode() {
     $q.dark.toggle();
     localStorage.setItem('darkModeEnabled', $q.dark.isActive.toString());
-}
-
-function getIsCurrentNetworkMenuItem(url: string) {
-    networksMenuItems.mainnet.forEach((item) => {
-        if (item.url === url) {
-            return true;
-        }
-    });
-    return false;
-}
-
-function goTo(to: string | { name: string }) {
-    blurActiveElement();
-    closeAllMenus();
-
-    const httpsRegex = /^https/;
-    if (typeof to === 'string' && httpsRegex.test(to)) {
-        window.open(to, '_blank');
-        return;
-    }
-
-    $router.push(to);
 }
 </script>
 
@@ -249,35 +212,18 @@ function goTo(to: string | { name: string }) {
             }"
         >
             <li
-                v-for="item in networksMenuItems.mainnet"
-                :key="`networks-submenu-item-mainnet-${item.label}`"
+                v-for="chain in chains"
+                :key="chain.network"
                 :class="{
                     'c-header-links__submenu-li': true,
-                    'c-header-links__submenu-li--current': getIsCurrentNetworkMenuItem(item.url),
+                    'c-header-links__submenu-li--current': multichainSelectedNetwork?.network === chain.network
                 }"
                 tabindex="0"
                 role="link"
-                @click="goTo(item.url)"
-                @keydown.enter="goTo(item.url)"
+                @click="switchChain(chain)"
+                @keydown.enter="switchChain(chain)"
             >
-                {{ item.label }}
-            </li>
-
-            <q-separator />
-
-            <li
-                v-for="item in networksMenuItems.testnet"
-                :key="`networks-submenu-item-testnet-${item.label}`"
-                :class="{
-                    'c-header-links__submenu-li': true,
-                    'c-header-links__submenu-li--current': getIsCurrentNetworkMenuItem(item.url),
-                }"
-                tabindex="0"
-                role="link"
-                @click="goTo(item.url)"
-                @keydown.enter="goTo(item.url)"
-            >
-                {{ item.label }}
+                {{ chain.settings.getDisplay() }}
             </li>
         </ul>
     </li>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -6,7 +6,7 @@ import {
     ref,
     watch,
 } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { setCssVar, useQuasar } from 'quasar';
 
 import AppHeader from 'components/header/AppHeader.vue';
@@ -15,8 +15,11 @@ import FooterMain from 'components/FooterMain.vue';
 import { getBrowserName } from 'src/lib/utils';
 import { useChainStore } from 'src/core';
 import { Themes } from 'src/core/types';
+import { initMultichain } from 'src/lib/multichain-utils';
 
 const $route = useRoute();
+const $router = useRouter();
+
 const $q = useQuasar();
 
 const scrollY = ref(0);
@@ -88,6 +91,11 @@ watch(() => $route.query.network, () => {
 watch(() => $q.dark.isActive, () => {
     setTheme();
 });
+
+onMounted(() => {
+    initMultichain($router, $route);
+});
+
 </script>
 
 <template>

--- a/src/lib/multichain-utils.ts
+++ b/src/lib/multichain-utils.ts
@@ -1,0 +1,99 @@
+import { evmSettings, TeloscanEVMChainSettings, useChainStore } from 'src/core';
+import { CURRENT_CONTEXT } from 'src/core/mocks';
+import { ref, watch } from 'vue';
+import { RouteLocationNormalizedLoaded, Router } from 'vue-router';
+
+export interface ChainOption {
+    network: string;
+    settings: TeloscanEVMChainSettings;
+}
+
+export const chains = [
+    {
+        network: 'telos-evm',
+        settings: evmSettings['telos-evm'],
+    },
+    {
+        network: 'telos-evm-testnet',
+        settings: evmSettings['telos-evm-testnet'],
+    },
+] as ChainOption[];
+
+console.log('process.env.NETWORK_EVM_NAME:', process.env.NETWORK_EVM_NAME); // FIXME: remove
+
+export const multichainSelectedNetwork = ref<ChainOption | undefined>(chains.find(chain => chain.network === process.env.NETWORK_EVM_NAME));
+
+export const switchChain = (chain: ChainOption) => {
+    console.log('Multichain switchChain()', { chain });
+    multichainSelectedNetwork.value = chain;
+    updateSelectedNetworkFromUserChoise();
+};
+
+const quasar = {
+    $router: null as never as Router,
+    $route: null as never as RouteLocationNormalizedLoaded,
+};
+
+export function initMultichain($router: Router, $route: RouteLocationNormalizedLoaded) {
+    quasar.$router = $router;
+    quasar.$route = $route;
+    console.log('Multichain initMultichain()');
+    const defaultNetwork = Object.keys(evmSettings)[0];
+    let network = new URLSearchParams(window.location.search).get('network');
+    if (network) {
+        const exists = Object.keys(evmSettings).some(key => evmSettings[key].getNetwork() === network);
+        if (!exists) {
+            network = defaultNetwork;
+        }
+    } else {
+        network = defaultNetwork;
+    }
+    quasar.$router.replace({ query: { ...quasar.$route.query, network } });
+    multichainSelectedNetwork.value = chains.find(chain => chain.network === network);
+}
+
+const chainStore = useChainStore();
+
+async function updateSelectedNetworkFromUrl() {
+    console.log('Multichain updateSelectedNetworkFromUrl()');
+
+    const network = new URLSearchParams(window.location.search).get('network');
+    if (network) {
+        const exists = Object.keys(evmSettings).some(key => evmSettings[key].getNetwork() === network);
+        if (exists) {
+            multichainSelectedNetwork.value = chains.find(chain => chain.network === network);
+        } else {
+            console.error('Multichain updateSelectedNetworkFromUrl() invalid network', { network });
+        }
+    }
+}
+
+async function updateSelectedNetworkFromUserChoise() {
+    console.log('Multichain updateSelectedNetworkFromChainStore()');
+    const network = multichainSelectedNetwork?.value?.network;
+    if (typeof network === 'string') {
+        chainStore.setChain(CURRENT_CONTEXT, network);
+        quasar.$router.replace({ query: { ...quasar.$route.query, network } });
+        return;
+    }
+    console.error('Multichain updateSelectedNetworkFromChainStore() invalid network', { network });
+}
+
+
+// watch(multichainSelectedNetwork, () => {
+//     console.log('Multichain watch multichainSelectedNetwork', { value: multichainSelectedNetwork.value, useRouter: useRouter() });
+//     if (multichainSelectedNetwork.value) {
+//         chainStore.setChain(CURRENT_CONTEXT, multichainSelectedNetwork.value.network);
+//         // replace the url to reflect the network
+//         const $route = useRoute();
+//         useRouter().replace({ query: { ...$route.query, network: multichainSelectedNetwork.value.network } });
+//     }
+// });
+//
+// watch(() => chainStore.currentChain, (currentChain) => {
+//     console.log('Multichain watch chainStore.currentChain', { network: currentChain.settings.getNetwork(), currentChain });
+//     multichainSelectedNetwork.value = chains.find(chain => chain.network === currentChain.settings.getNetwork());
+// });
+
+// watch(() => multichainSelectedNetwork, () => updateSelectedNetworkFromUserChoise());
+watch(() => window.location.search, () => updateSelectedNetworkFromUrl());


### PR DESCRIPTION
# Fixes #902

This PR is included in [this other PR](https://github.com/telosnetwork/teloscan/pull/904)

## Description
This PR fixes not only the low-resolution buttons to switch between networks but also refactors the whole implementation from the original component code to a utils-multichain-specific shared script that incorporates reacting and updating the network parameter. The default value is based on the `NETWORK_EVM_NAME` environment variable.

## Test scenarios
... to be continued