### PR TITLE
First page of Transactions Page was skipping last transactions

### DIFF
--- a/src/components/TransactionTable.vue
+++ b/src/components/TransactionTable.vue
@@ -142,17 +142,18 @@ watch(() => route.query,
         let page = p ? Number(p) : 0;
         let size = rowsPerPage ? Number(rowsPerPage) : pagination.value.rowsPerPage;
         let desc = sort ? sort === 'DESC' : true;
-
+        console.log('TransactionTable.watch() ->', { query, page, size, desc });
         setPagination(page, size, desc);
     },
     { immediate: true },
 );
 
 function setPagination(page: number, size: number, desc: boolean) {
+    console.log('TransactionTable.setPagination(1) ->', { page, size, desc });
     pagination.value.page = page;
     pagination.value.rowsPerPage = size;
     pagination.value.descending = desc;
-
+    console.log('TransactionTable.setPagination(2) ->', { initialKey: pagination.value.initialKey, pagination: pagination.value, page });
     if (pagination.value.initialKey > 0) {
         // key is page pages away from the initial key
         const zero_base_page = page - 1;
@@ -201,6 +202,7 @@ async function parseTransactions() {
         if (results.length > 0) {
             const firstItemKey = results[0].id;
             pagination.value.initialKey = firstItemKey + 1;
+            console.log('TransactionTable.parseTransactions() ->', { firstItemKey, initialKey: pagination.value.initialKey });
         }
 
         transactions.splice(0, transactions.length, ...results);
@@ -271,9 +273,11 @@ async function getPath() {
         path = `v1/transactions?limit=${limit}`;
         if (pagination.value.initialKey === 0) {
             // in the case of the first query, we need to get the initial key
-            let response = await useChainStore().currentChain.settings.getIndexerApi().get('v1/transactions?includePagination=true&key=0');
-            const next = response.data.next;
-            pagination.value.initialKey = next + 1;
+            console.log('TransactionTable.getPath() ->', { initialKey: pagination.value.initialKey });
+            let response = await useChainStore().currentChain.settings.getIndexerApi().get('/v1/transactions?limit=6');
+            const next = response.data.results[0].id;
+            pagination.value.initialKey = next;
+            console.log('TransactionTable.getPath() ->', { initialKey: pagination.value.initialKey, response, next });
         }
         let currentKey = pagination.value.initialKey - ((page - 1) * rowsPerPage);
         if (currentKey < 0) {

--- a/src/components/TransactionTable.vue
+++ b/src/components/TransactionTable.vue
@@ -142,18 +142,15 @@ watch(() => route.query,
         let page = p ? Number(p) : 0;
         let size = rowsPerPage ? Number(rowsPerPage) : pagination.value.rowsPerPage;
         let desc = sort ? sort === 'DESC' : true;
-        console.log('TransactionTable.watch() ->', { query, page, size, desc });
         setPagination(page, size, desc);
     },
     { immediate: true },
 );
 
 function setPagination(page: number, size: number, desc: boolean) {
-    console.log('TransactionTable.setPagination(1) ->', { page, size, desc });
     pagination.value.page = page;
     pagination.value.rowsPerPage = size;
     pagination.value.descending = desc;
-    console.log('TransactionTable.setPagination(2) ->', { initialKey: pagination.value.initialKey, pagination: pagination.value, page });
     if (pagination.value.initialKey > 0) {
         // key is page pages away from the initial key
         const zero_base_page = page - 1;
@@ -202,7 +199,6 @@ async function parseTransactions() {
         if (results.length > 0) {
             const firstItemKey = results[0].id;
             pagination.value.initialKey = firstItemKey + 1;
-            console.log('TransactionTable.parseTransactions() ->', { firstItemKey, initialKey: pagination.value.initialKey });
         }
 
         transactions.splice(0, transactions.length, ...results);
@@ -273,11 +269,9 @@ async function getPath() {
         path = `v1/transactions?limit=${limit}`;
         if (pagination.value.initialKey === 0) {
             // in the case of the first query, we need to get the initial key
-            console.log('TransactionTable.getPath() ->', { initialKey: pagination.value.initialKey });
             let response = await useChainStore().currentChain.settings.getIndexerApi().get('/v1/transactions?limit=6');
             const next = response.data.results[0].id;
             pagination.value.initialKey = next;
-            console.log('TransactionTable.getPath() ->', { initialKey: pagination.value.initialKey, response, next });
         }
         let currentKey = pagination.value.initialKey - ((page - 1) * rowsPerPage);
         if (currentKey < 0) {


### PR DESCRIPTION
# Fixes #911

## Description
The key computation was fixed to establish a correct initial key from which to navigate.
Now the first page queried includes the last transaction registered by the indexer.

## Test scenarios
https://deploy-preview-914--dev-mainnet-teloscan.netlify.app/

[teloscan---first-transactions-page-fixed.webm](https://github.com/user-attachments/assets/a8e86fbc-0c9a-4dc6-9809-f7b09605b945)
