### PR TITLE
clearing the address url parameter on internal transactions navigation

### DIFF
--- a/src/boot/core.ts
+++ b/src/boot/core.ts
@@ -7,7 +7,6 @@ export default boot(({ app }) => {
 
     const defaultNetwork = Object.keys(evmSettings)[0];
     let network = new URLSearchParams(window.location.search).get('network') ?? process.env.NETWORK_EVM_NAME;
-    console.log('Multichain initMultichain()', { network, NETWORK_EVM_NAME: process.env.NETWORK_EVM_NAME });
     if (network) {
         const exists = Object.keys(evmSettings).some(key => evmSettings[key].getNetwork() === network);
         if (!exists) {

--- a/src/components/InternalTransactionFlatTable.vue
+++ b/src/components/InternalTransactionFlatTable.vue
@@ -103,6 +103,7 @@ export default {
             page_size_options: [10, 20, 50],
             showDateAge: true,
             allExpanded: false,
+            timer: null,
         };
     },
     async created() {
@@ -137,21 +138,25 @@ export default {
     },
     methods: {
         updateData() {
-            const _pag = this.$route.query.page;
-            let pag = _pag;
-            let page = 1;
-            let size = this.page_size_options[0];
+            clearTimeout(this.timer);
+            this.timer = setTimeout(() => {
+                // we need to wait a bit to allow the URL to be updated
+                const _pag = this.$route.query.page;
+                let pag = _pag;
+                let page = 1;
+                let size = this.page_size_options[0];
 
-            // we also allow to pass a single number as the page number
-            if (typeof pag === 'number') {
-                page = pag;
-            } else if (typeof pag === 'string') {
-                // we also allow to pass a string of two numbers: 'page,rowsPerPage'
-                const [p, s] = pag.split(',');
-                page = p;
-                size = s;
-            }
-            this.setPagination(page, size);
+                // we also allow to pass a single number as the page number
+                if (typeof pag === 'number') {
+                    page = pag;
+                } else if (typeof pag === 'string') {
+                    // we also allow to pass a string of two numbers: 'page,rowsPerPage'
+                    const [p, s] = pag.split(',');
+                    page = p;
+                    size = s;
+                }
+                this.setPagination(page, size);
+            }, 100);
         },
         getDirection: getDirection,
         updateLoadingRows() {

--- a/src/pages/InternalTrxPage.vue
+++ b/src/pages/InternalTrxPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 
@@ -9,7 +9,14 @@ import AddressField from 'components/AddressField.vue';
 
 const { t: $t } = useI18n();
 const route = useRoute();
-const address = computed(() => route.query.a as string);
+/// const address = computed(() => route.query.a as string);
+const address = ref<string>(route.query.a as string);
+
+// watch the route url and if it chenges update the address
+watch(() => route.query.a, () => {
+    address.value = route.query.a as string ? route.query.a as string : '';
+},
+{ immediate: true });
 
 </script>
 


### PR DESCRIPTION
# Fixes #882 

## Description
The address parameter seemed to update after the query was made so even when you click on the internal transactions button (with no address filter) it does not change the filter until the second click to keep on navigating (It takes a delayed effect).

This PR adds a little bouncing to wait for the address parameter to update before performing the actual query so now it make it with the correct address filter.

## Test scenarios
