### PR TITLE
#935 | Fixing broken token balances section for address page

### DIFF
--- a/src/components/Token/TokenList.vue
+++ b/src/components/Token/TokenList.vue
@@ -86,17 +86,26 @@ export default {
                     tokensOfficial.push(token);
                     return token;
                 } else if(result.contract !== '___NATIVE_CURRENCY___'){
-                    let contract = await contractManager.getContract(result.contract);
-                    result.address = contract.address;
-                    result.name = contract.name;
-                    result.symbol = contract.properties?.symbol;
-                    result.decimals = contract.properties?.decimals;
-                    result.price = contract.properties?.price || 0;
-                    result.contract = contract;
-                    result.logoURI = DEFAULT_TOKEN_LOGO;
-                    result.fullBalance = `${formatWei(result.balance, result.contract.properties?.decimals)}`;
-                    result.balance = `${formatWei(result.balance, result.contract.properties?.decimals, 4)}`;
-                    tokens.push(result);
+                    try {
+                        let contract = await contractManager.getContract(result.contract);
+                        result.address = contract.address;
+                        result.name = contract.name;
+                        result.symbol = contract.properties?.symbol;
+                        result.decimals = contract.properties?.decimals;
+                        result.price = contract.properties?.price || 0;
+                        result.contract = contract;
+                        result.logoURI = DEFAULT_TOKEN_LOGO;
+                        result.fullBalance = `${formatWei(result.balance, result.contract.properties?.decimals)}`;
+                        result.balance = `${formatWei(result.balance, result.contract.properties?.decimals, 4)}`;
+                        tokens.push(result);
+                    } catch (e) {
+                        console.error('Error loading token', {
+                            error: e,
+                            contract: result.contract,
+                            token: result,
+                        });
+                        return result;
+                    }
                     return result;
                 }
             }));

--- a/src/lib/contract/ContractManager.js
+++ b/src/lib/contract/ContractManager.js
@@ -261,7 +261,11 @@ export default class ContractManager {
     addContractsToCache(contracts){
         for(const index in contracts){
             // skipping non-real contracts
-            if (contracts[index].creator) {
+            if (
+                contracts[index].creator ||
+                contracts[index].name ||
+                contracts[index].calldata
+            ) {
                 this.addContractToCache(index, contracts[index]);
             }
         }


### PR DESCRIPTION
# Fixes #935 

## Description
A few changes were made to ensure we always cache contracts that may come in any response. Also, put the crashing code inside a try-catch statement to avoid infinite loading.

## Test scenarios
https://deploy-preview-936--dev-mainnet-teloscan.netlify.app/address/0xbccc4b4c6530F82FE309c5E845E50b5E9C89f2AD?tab=tokens
![image](https://github.com/user-attachments/assets/25f92c0c-26ab-4000-90c6-09f22f11b024)
