### PR TITLE
#948 | token swaps duplicated in transaction view

### DIFF
--- a/src/components/Transaction/ERCTransferList.vue
+++ b/src/components/Transaction/ERCTransferList.vue
@@ -5,7 +5,7 @@ import { useI18n } from 'vue-i18n';
 import { useQuasar } from 'quasar';
 import { BigNumber } from 'ethers';
 
-import { EvmLogs  } from 'src/core/types/EvmLog';
+import { EvmLog, EvmLogs  } from 'src/core/types/EvmLog';
 import AddressField from 'components/AddressField.vue';
 import ValueField from 'components/ValueField.vue';
 import { ERC721Transfer, ERC1155Transfer, ERC20Transfer, TokenBasicData } from 'src/types';
@@ -40,105 +40,127 @@ const erc721_transfers  = ref<ERC721Transfer[]>([]);
 const erc1155_transfers = ref<ERC1155Transfer[]>([]);
 const erc20_transfers   = ref<ERC20Transfer[]>([]);
 
+const resetTransfers = () => {
+    erc721_transfers.value = [];
+    erc1155_transfers.value = [];
+    erc20_transfers.value = [];
+};
+
+const processLog = async (log: EvmLog): Promise<ERC20Transfer | ERC721Transfer | ERC1155Transfer | null> => {
+    const contractManager = useChainStore().currentChain.settings.getContractManager();
+
+    let sig = log.topics[0].substring(0, 10);
+    if (TRANSFER_SIGNATURES.includes(sig)) {
+        let type = contractManager.getTokenTypeFromLog(log);
+        let contract = await contractManager.getContract(log.address, type);
+        if (typeof contract.properties !== 'undefined' && contract.properties !== null) {
+            let token: TokenBasicData = {
+                'symbol': contract.properties.symbol,
+                'address': log.address,
+                'name': contract.properties.name,
+                'decimals': contract.properties.decimals,
+            };
+            if (type === 'erc721') {
+                let tokenId = BigNumber.from(log.topics[3]).toString();
+                if (contract.token.extensions?.metadata) {
+                    try {
+                        token = await contractManager.loadTokenMetadata(
+                            log.address,
+                            contract.token,
+                            tokenId,
+                        );
+                    } catch (e: any) {
+                        console.error(`Could not retreive metadata for ${contract.address}: ${e.message}`);
+                        // notify the user
+                        $q.notify({
+                            message: $t(
+                                'pages.couldnt_retreive_metadata_for_address',
+                                { address: contract.address, message: e.message },
+                            ),
+                            color: 'negative',
+                            position: 'top',
+                            timeout: 5000,
+                        });
+                    }
+                }
+                return {
+                    'tokenId': tokenId,
+                    'to': '0x' + log.topics[2].substring(log.topics[2].length - 40, 40),
+                    'from': '0x' + log.topics[1].substring(log.topics[1].length - 40, 40),
+                    'token': token,
+                } as ERC721Transfer;
+            } else if (type === 'erc1155') {
+                let tokenId = BigNumber.from(log.data.substring(0, 66)).toString();
+                if (contract.token.extensions?.metadata) {
+                    try {
+                        token = await contractManager.loadTokenMetadata(
+                            log.address,
+                            contract.token,
+                            tokenId,
+                        );
+                    } catch (e: any) {
+                        console.error(`Could not retreive metadata for ${contract.address}: ${e.message}`);
+                        // notify the user
+                        $q.notify({
+                            message: $t(
+                                'pages.couldnt_retreive_metadata_for_address',
+                                { address: contract.address, message: e.message },
+                            ),
+                            color: 'negative',
+                            position: 'top',
+                            timeout: 5000,
+                        });
+                    }
+                }
+                return {
+                    'tokenId': tokenId,
+                    'amount': BigNumber.from(log.data).toString(),
+                    'to': '0x' + log.topics[3].substring(log.topics[3].length - 40, 40),
+                    'from': '0x' + log.topics[2].substring(log.topics[2].length - 40, 40),
+                    'token': token,
+                } as ERC1155Transfer;
+            } else {
+                return {
+                    'value': log.data,
+                    'wei': BigNumber.from(log.data).toString(),
+                    'from': '0x' + log.topics[1].substring(log.topics[1].length - 40),
+                    'to': '0x' + log.topics[2].substring(log.topics[2].length - 40),
+                    'token': token,
+                } as ERC20Transfer;
+            }
+        }
+    }
+
+    return null;
+};
+
 const loadTransfers = async () => {
     if (!props.logs || props.logs.length === 0) {
         emit('transfers-count', 0);
         return;
     }
 
-    const contractManager = useChainStore().currentChain.settings.getContractManager();
-
     const logs = props.logs as EvmLogs;
-
+    const promises = [];
     for (const log of logs) {
-        // ERC20, ERC721 & ERC1155 transfers (ERC721 & ERC20 have same first topic but ERC20 has 4 topics for
-        // transfers, ERC20 has 3 log topics, ERC1155 has a different first topic)
-        let sig = log.topics[0].substring(0, 10);
-        if (TRANSFER_SIGNATURES.includes(sig)) {
-            let type = contractManager.getTokenTypeFromLog(log);
-            let contract = await contractManager.getContract(log.address, type);
-            if (typeof contract.properties !== 'undefined' && contract.properties !== null) {
-                let token: TokenBasicData = {
-                    'symbol': contract.properties.symbol,
-                    'address': log.address,
-                    'name': contract.properties.name,
-                    'decimals': contract.properties.decimals,
-                };
-                if (type === 'erc721') {
-                    console.error('NOT IMPLEMENTED: ERC721 transfers');
-                    let tokenId = BigNumber.from(log.topics[3]).toString();
-                    if (contract.token.extensions?.metadata) {
-                        try {
-                            token = await contractManager.loadTokenMetadata(
-                                log.address,
-                                contract.token,
-                                tokenId,
-                            );
-                        } catch (e: any) {
-                            console.error(`Could not retreive metadata for ${contract.address}: ${e.message}`);
-                            // notify the user
-                            $q.notify({
-                                message: $t(
-                                    'pages.couldnt_retreive_metadata_for_address',
-                                    { address: contract.address, message: e.message },
-                                ),
-                                color: 'negative',
-                                position: 'top',
-                                timeout: 5000,
-                            });
-                        }
-                    }
-                    erc721_transfers.value.push({
-                        'tokenId': tokenId,
-                        'to': '0x' + log.topics[2].substring(log.topics[2].length - 40, 40),
-                        'from': '0x' + log.topics[1].substring(log.topics[1].length - 40, 40),
-                        'token': token,
-                    });
-                } else if (type === 'erc1155') {
-                    console.error('NOT IMPLEMENTED: ERC1155 transfers');
-                    let tokenId = BigNumber.from(log.data.substring(0, 66)).toString();
-                    if (contract.token.extensions?.metadata) {
-                        try {
-                            token = await contractManager.loadTokenMetadata(
-                                log.address,
-                                contract.token,
-                                tokenId,
-                            );
-                        } catch (e: any) {
-                            console.error(`Could not retreive metadata for ${contract.address}: ${e.message}`);
-                            // notify the user
-                            $q.notify({
-                                message: $t(
-                                    'pages.couldnt_retreive_metadata_for_address',
-                                    { address: contract.address, message: e.message },
-                                ),
-                                color: 'negative',
-                                position: 'top',
-                                timeout: 5000,
-                            });
-                        }
-                    }
-                    erc1155_transfers.value.push({
-                        'tokenId': tokenId,
-                        'amount': BigNumber.from(log.data).toString(),
-                        'to': '0x' + log.topics[3].substring(log.topics[3].length - 40, 40),
-                        'from': '0x' + log.topics[2].substring(log.topics[2].length - 40, 40),
-                        'token': token,
-                    });
-                } else {
+        promises.push(processLog(log));
+    }
 
-                    erc20_transfers.value.push({
-                        'value': log.data,
-                        'wei': BigNumber.from(log.data).toString(),
-                        'from': '0x' + log.topics[1].substring(log.topics[1].length - 40),
-                        'to': '0x' + log.topics[2].substring(log.topics[2].length - 40),
-                        'token': token,
-                    });
-                }
+    const transfers = await Promise.all(promises);
+    resetTransfers();
+    for (const transfer of transfers) {
+        if (transfer) {
+            if ('amount' in transfer) {
+                erc1155_transfers.value.push(transfer as ERC1155Transfer);
+            } else if ('tokenId' in transfer) {
+                erc721_transfers.value.push(transfer as ERC721Transfer);
+            } else if ('value' in transfer) {
+                erc20_transfers.value.push(transfer as ERC20Transfer);
+            } else {
+                console.error('Unknown transfer type', transfer);
             }
         }
     }
-
     const count = erc20_transfers.value.length + erc721_transfers.value.length + erc1155_transfers.value.length;
     emit('transfers-count', count);
 };

--- a/src/components/Transaction/TLOSTransferList.vue
+++ b/src/components/Transaction/TLOSTransferList.vue
@@ -111,6 +111,7 @@ watch(() => props.transaction, async (newTrx) => {
             />
         </div>
     </div>
+    <q-skeleton v-if="loading" />
 </div>
 </template>
 

--- a/src/components/TransactionOverview.vue
+++ b/src/components/TransactionOverview.vue
@@ -367,6 +367,7 @@ onMounted(() => {
                 :transaction="trx"
                 @transfers-count="setTLOSTransfersCount"
             />
+            <q-skeleton v-else type="text" class="c-trx-overview__skeleton" />
         </div>
     </div>
 

--- a/src/pages/TransactionPage.vue
+++ b/src/pages/TransactionPage.vue
@@ -123,7 +123,7 @@ const nextTransaction = () => {
                     </q-card>
 
                     <!-- Transaction Overview -->
-                    <div v-else class="c-transactions__panel-content--overview c-transactions__panel-content">
+                    <div v-else-if="tab === 'overview'" class="c-transactions__panel-content--overview c-transactions__panel-content">
                         <TransactionOverview
                             :trx="trx"
                         />


### PR DESCRIPTION
# Fixes #948 

## Description
This PR makes sure that no duplicated ERC20 transfer is shown In the Transaction page overview

## Test scenarios
Original problem: https://www.teloscan.io/tx/0x77c29b71aa69a5756c4c2f00530e8f02376175d7102a9d084237f9782e9ea113?tab=overview



![image](https://github.com/user-attachments/assets/9aa8fc18-17bb-4d09-a9ab-f968405b7dd0)
