### PR TITLE
#950 | Fix incorrect export URL

### DIFF
--- a/src/lib/data-export-utils.ts
+++ b/src/lib/data-export-utils.ts
@@ -75,7 +75,7 @@ export async function downloadCsv(
     }
 
     try {
-        const exportApi = useChainStore().currentChain.settings.getTelosApi();
+        const exportApi = useChainStore().currentChain.settings.getIndexerApi();
         const { data } = await exportApi.get(url);
         csvContent = data;
     } catch (e) {


### PR DESCRIPTION
# Fixes #950

## Description
The URL of the Export functionality was pointing to the wrong domain. Instead of using the indexer, it was using the telos-API server.

## Test scenarios
