### PR TITLE
#957 | fix Transaction page tab update after another trx search

### DIFF
--- a/src/pages/TransactionPage.vue
+++ b/src/pages/TransactionPage.vue
@@ -23,7 +23,7 @@ const trx = ref<EvmTransactionExtended | null>(null);
 const updateData = async () => {
     trx.value = await loadTransaction(hash.value);
     trxNotFound.value = !trx.value;
-    if (!trx.value) {
+    if (!trx.value || !route.query.tab) {
         tab.value = defaultTab;
     }
 };


### PR DESCRIPTION
# Fixes #957

## Description
This PR fixes the problem of the page not updating while you are standing on the Transactions page, specifically on Internal Transactions tab and you search for another transaction and click on the result.

Now the page changes the tab to Overvew and updates all data.

## Test scenarios
- Go to https://deploy-preview-961--dev-mainnet-teloscan.netlify.app/tx/0xa3c1244a7fd6e188ad1002d6331ba811f6d1bc4f09384856133d8f243daecf7c?tab=internal
- Be sure to be on the Internal Transaction Tab
- Search for trx: 0xc58e32fb95a54c5f6522f950855e8c153d6204ff6bbd383663cae115a86b7f62
- Click on result
- The page data should be updated
