### PR TITLE
#942 | Display clear empty state for addresscontract transaction tables

### DIFF
--- a/src/components/EmptyTableSign.vue
+++ b/src/components/EmptyTableSign.vue
@@ -1,0 +1,48 @@
+<script lang="ts" setup>
+// src/components/EmptyTableSign.vue
+import { useI18n } from 'vue-i18n';
+const $i18n = useI18n();
+const { t: $t } = $i18n;
+
+</script>
+
+<template>
+<div class="c-empty-table-sign">
+    <div class="c-empty-table-sign-title">
+        <q-icon
+            class="c-empty-table-sign-title-icon"
+            name="fa fa-table"
+        />
+        {{ $t('components.no_matching_entries') }}
+    </div>
+    <div class="c-empty-table-sign-description">
+        {{ $t('components.please_try_again_later') }}
+    </div>
+</div>
+
+</template>
+
+<style lang="scss">
+.c-empty-table-sign {
+    padding: 20px;
+    text-align: center;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    &-title {
+        font-size: 1.2rem;
+        margin-bottom: 10px;
+        &-icon {
+            font-size: 1.2rem;
+            margin-right: 5px;
+            margin-top: -7px;
+        }
+    }
+    &-description {
+        font-size: 0.8rem;
+    }
+}
+</style>
+

--- a/src/components/InternalTransactionFlatTable.vue
+++ b/src/components/InternalTransactionFlatTable.vue
@@ -4,6 +4,7 @@ import DateField from 'components/DateField';
 import TransactionField from 'components/TransactionField';
 import AddressField from 'components/AddressField';
 import ValueField from 'components/ValueField.vue';
+import EmptyTableSign from 'components/EmptyTableSign.vue';
 import { getDirection } from 'src/lib/transaction-utils';
 import { useChainStore } from 'src/core';
 
@@ -15,6 +16,7 @@ export default {
         DateField,
         BlockField,
         ValueField,
+        EmptyTableSign,
     },
     props: {
         address: {
@@ -308,6 +310,9 @@ export default {
     :rows-per-page-options="page_size_options"
     @request="onPaginationChange"
 >
+    <template v-slot:no-data>
+        <EmptyTableSign />
+    </template>
     <template v-if="!usePagination" v-slot:bottom>
         <q-card-actions
             align="center"

--- a/src/components/NftTransfersTable.vue
+++ b/src/components/NftTransfersTable.vue
@@ -9,6 +9,8 @@ import MethodField from 'components/MethodField.vue';
 import AddressField from 'components/AddressField.vue';
 import NftItemField from 'components/NftItemField.vue';
 import DateField from 'components/DateField.vue';
+import EmptyTableSign from 'components/EmptyTableSign.vue';
+
 import { formatWei, toChecksumAddress } from 'src/lib/utils';
 import { NftTransferProps, NftTransferData } from 'src/types';
 
@@ -320,6 +322,9 @@ onMounted(() => {
     :rows-per-page-options="[10, 20, 50]"
     @request="onRequest"
 >
+    <template v-slot:no-data>
+        <EmptyTableSign />
+    </template>
     <template v-slot:header="props">
         <q-tr :props="props">
             <q-th

--- a/src/components/Token/NFTList.vue
+++ b/src/components/Token/NFTList.vue
@@ -7,6 +7,8 @@ import { ALLOWED_VIDEO_EXTENSIONS } from 'src/lib/utils';
 import AddressField from 'components/AddressField.vue';
 import BlockField from 'components/BlockField.vue';
 import ImagePopup from 'src/components/ImagePopup.vue';
+import EmptyTableSign from 'components/EmptyTableSign.vue';
+
 import { NFT, NFT_TYPE } from 'src/types/NFT';
 import { useChainStore } from 'src/core';
 import { QTableProps, useQuasar } from 'quasar';
@@ -247,6 +249,9 @@ watch(() => $route.query.network, () => {
         :columns="columns"
         :rows-per-page-options="[10, 20, 50]"
     >
+        <template v-slot:no-data>
+            <EmptyTableSign />
+        </template>
         <template v-slot:header="props">
             <q-tr :props="props">
                 <q-th

--- a/src/components/TransactionTable.vue
+++ b/src/components/TransactionTable.vue
@@ -16,6 +16,7 @@ import MethodField from 'components/MethodField.vue';
 import TransactionDialog from 'components/TransactionDialog.vue';
 import TransactionField from 'components/TransactionField.vue';
 import TransactionFeeField from 'components/TransactionFeeField.vue';
+import EmptyTableSign from 'components/EmptyTableSign.vue';
 
 import { PaginationByKey } from 'src/types';
 import { useStore } from 'vuex';
@@ -370,6 +371,9 @@ onBeforeMount(() => {
         :rows-per-page-options="page_size_options"
         @request="onPaginationChange"
     >
+        <template v-slot:no-data>
+            <EmptyTableSign />
+        </template>
         <template v-slot:header="props">
             <q-tr :props="props">
                 <q-th
@@ -569,6 +573,7 @@ onBeforeMount(() => {
 }
 
 .c-transaction-table {
+
     &__limit-text {
         height: 26px;
         color: var(--text-color);

--- a/src/i18n/de-de/index.js
+++ b/src/i18n/de-de/index.js
@@ -242,6 +242,8 @@ export default {
         click_to_toggle_media_size: 'Klicken, um die Mediengröße umzuschalten',
         toggle_expand: 'Passform auf Bildschirm oder Originalgröße umschalten',
         close: 'Schließen',
+        no_matching_entries: 'Keine passenden Einträge',
+        please_try_again_later: 'Bitte versuchen Sie es später erneut',
         input_viewer: {
             name: 'Name',
             type: 'Typ',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -245,6 +245,8 @@ export default {
         click_to_toggle_media_size: 'Click to toggle media size',
         toggle_expand: 'Toggle fit to screen of original size',
         close: 'Close',
+        no_matching_entries: 'No matching entries',
+        please_try_again_later: 'Please try again later',
         input_viewer: {
             name: 'Name',
             type: 'Type',

--- a/src/i18n/es-es/index.js
+++ b/src/i18n/es-es/index.js
@@ -242,6 +242,8 @@ export default {
         click_to_toggle_media_size: 'haga click para cambiar el tamaño del medio',
         toggle_expand: 'Alternar ajuste a pantalla o tamaño original',
         close: 'Cerrar',
+        no_matching_entries: 'No hay entradas coincidentes',
+        please_try_again_later: 'Por favor, inténtalo de nuevo más tarde',
         input_viewer: {
             name: 'Nombre',
             type: 'Tipo',

--- a/src/i18n/fr-fr/index.js
+++ b/src/i18n/fr-fr/index.js
@@ -242,6 +242,8 @@ export default {
         click_to_toggle_media_size: 'Cliquez pour changer la taille du média',
         toggle_expand: 'Basculer pour s\'adapter à l\'écran ou taille originale',
         close: 'Fermer',
+        no_matching_entries: 'Aucune entrée correspondante',
+        please_try_again_later: 'Veuillez réessayer plus tard',
         input_viewer: {
             name: 'Nom',
             type: 'Type',

--- a/src/i18n/pt-br/index.js
+++ b/src/i18n/pt-br/index.js
@@ -242,6 +242,8 @@ export default {
         click_to_toggle_media_size: 'Clique para alternar o tamanho da mídia',
         toggle_expand: 'Alternar ajuste à tela ou tamanho original',
         close: 'Fechar',
+        no_matching_entries: 'Nenhuma entrada correspondente',
+        please_try_again_later: 'Por favor, tente novamente mais tarde',
         input_viewer: {
             name: 'Nome',
             type: 'Tipo',


### PR DESCRIPTION
# Fixes #942

## Description
This PR creates a new component to display a nice sign saying there's no matching data for the empty table. It was used in all tables on the website.


## Test scenarios
https://deploy-preview-965--dev-mainnet-teloscan.netlify.app/address/0x6A8cC581c663Af575162dBDcAAd53fAC1e5A5478

![image](https://github.com/user-attachments/assets/bb26b156-c6f2-4b63-b735-57dc503c4f3f)
![image](https://github.com/user-attachments/assets/0de482ee-9ede-4463-be0a-77081b818d56)
![image](https://github.com/user-attachments/assets/e3705d7f-5106-4939-ae00-690147b78ced)
![image](https://github.com/user-attachments/assets/efd8f69a-e5f2-495f-a882-f0779b93fc7b)
