### PR TITLE
#969 | unsupported fragment error better handled

### DIFF
--- a/src/components/TransactionTable.vue
+++ b/src/components/TransactionTable.vue
@@ -228,7 +228,9 @@ async function parseTransactions() {
                         const value = BigNumber.from(value_str);
                         const sighash = transaction.input.slice(0, 10);
                         const signature = abi[sighash] as string;
-                        const name = signature.split('(')[0].replace('function ', '');
+                        const name = typeof signature === 'string' ?
+                            signature.split('(')[0].replace('function ', '') :
+                            sighash;
                         transaction.parsedTransaction = {
                             name,
                             sighash,

--- a/src/core/chains/EVMChainSettings.ts
+++ b/src/core/chains/EVMChainSettings.ts
@@ -142,9 +142,8 @@ export default abstract class EVMChainSettings implements ChainSettings {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const self = this;
         this.indexer.interceptors.response.use(function (response) {
-            if(response.data?.abi?.length > 0){
+            if(response.data?.abi){
                 for (const [key, value] of Object.entries(response.data.abi)) {
-                    self.getContractManager().parser.addFunctionInterface(key, value);
                     self.getFragmentParser().addFunctionInterface(key, value);
                 }
             }

--- a/src/lib/contract/ContractManager.js
+++ b/src/lib/contract/ContractManager.js
@@ -141,6 +141,11 @@ export default class ContractManager {
         if (data === '0x' || !data || !contract) {
             return false;
         }
+
+        const functionIface = await this.parser.getFunctionInterface(data);
+        if (!functionIface) {
+            return false;
+        }
         if (contract.getInterface()) {
             try {
                 let transaction = await contract.getInterface().parseTransaction({ data });
@@ -154,15 +159,12 @@ export default class ContractManager {
             }
         }
         try {
-            const functionIface = await this.parser.getFunctionInterface(data);
-            if (functionIface) {
-                let transaction = functionIface.parseTransaction({ data });
-                if(!transfers){
-                    return transaction;
-                }
-                transaction.transfers = await this.getTransfers(raw);
+            let transaction = functionIface.parseTransaction({ data });
+            if(!transfers){
                 return transaction;
             }
+            transaction.transfers = await this.getTransfers(raw);
+            return transaction;
         } catch (e) {
             console.warn(`Unable to parse transaction data using abi for ${contract.address}: ${e}`);
         }

--- a/src/lib/contract/FragmentParser.js
+++ b/src/lib/contract/FragmentParser.js
@@ -10,6 +10,7 @@ export default class FragmentParser {
         this.eventInterfaces = events_overrides;
         this.processing = [];
         this.evmEndpoint = evmEndpoint;
+        this.id = Math.floor(Math.random() * 100);
     }
 
     async addEventInterface(hex, signature){
@@ -19,7 +20,8 @@ export default class FragmentParser {
         this.eventInterfaces[hex] = signature;
     }
     async addFunctionInterface(hex, signature){
-        if (Object.prototype.hasOwnProperty.call(this.functionInterfaces, hex)) {
+        if (!signature) {
+            console.warn('indexer provides an incorrect abi value', { hex, signature });
             return;
         }
         this.functionInterfaces[hex] = signature;
@@ -27,20 +29,10 @@ export default class FragmentParser {
 
     async getFunctionInterface(data) {
         let prefix = data.toLowerCase().slice(0, 10);
-        if(prefix === '0x'){
-            return;
+        let funcName = this.functionInterfaces[prefix];
+        if (typeof funcName === 'string') {
+            return new ethers.utils.Interface([funcName]);
         }
-        if (Object.prototype.hasOwnProperty.call(this.functionInterfaces, prefix)) {
-            return new ethers.utils.Interface([this.functionInterfaces[prefix]]);
-        }
-        if(this.processing.includes(data)){
-            await new Promise(resolve => setTimeout(resolve, 300));
-            let result = await this.getFunctionInterface(data);
-            return result;
-        }
-        this.processing.push(data);
-
-        this.functionInterfaces[prefix] = '';
         return false;
     }
     async getEventInterface(data) {


### PR DESCRIPTION
# Fixes #969

## Description
The original problem for this error is the indexer returning null values as function names in the abi section. This PR handles this situation better and prints a more descriptive, clear warning text.

A new issue was created for the indexer to table this situation: https://github.com/telosnetwork/teloscan-indexer/issues/322

## Test scenarios
![image](https://github.com/user-attachments/assets/d552b0fc-b940-42cb-a293-67a883672ecc)