### PR TITLE
#972 | HoldersList showing a spinner until being ready

### DIFF
--- a/src/components/Token/HolderList.vue
+++ b/src/components/Token/HolderList.vue
@@ -103,6 +103,7 @@ const weHaveIndexerSupport = ref(false);
 const holders = ref<EvmHolder[]>([]);
 const loadingRows = ref<number[]>([]);
 const loading = ref(false);
+const ready = ref(false);
 const systemContractsList = ref('');
 const showSystemContracts = ref(false);
 
@@ -244,6 +245,7 @@ onMounted(async () => {
     // Listen for indexer readiness
     chainSettings.value.indexerReady$.subscribe(() => {
         weHaveIndexerSupport.value = chainSettings.value.hasIndexerSupportOver(minimumVersion);
+        ready.value = true;
         clearTimeout(timer);
         if (!loading.value) {
             onRequest();
@@ -536,7 +538,16 @@ function calculateDollarValue(row: EvmHolder): string {
 </script>
 
 <template>
-<template v-if="!weHaveIndexerSupport && !loading">
+<template v-if="!ready">
+    <q-card class="c-holder-list__spinner-container">
+        <q-spinner-dots
+            class="c-holder-list__spinner"
+            color="primary"
+            size="40px"
+        />
+    </q-card>
+</template>
+<template v-else-if="!weHaveIndexerSupport && !loading">
     <MinimumVersionRequired
         class="c-minimum-version-required"
         :required="minimumVersion"
@@ -793,5 +804,12 @@ function calculateDollarValue(row: EvmHolder): string {
 
 .c-minimum-version-required {
     align-self: center;
+}
+
+.c-holder-list__spinner-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100px;
 }
 </style>

--- a/src/components/Token/HolderList.vue
+++ b/src/components/Token/HolderList.vue
@@ -538,14 +538,7 @@ function calculateDollarValue(row: EvmHolder): string {
 </script>
 
 <template>
-<template v-if="!ready">
-    <q-card class="c-holder-list__spinner-container">
-        <q-skeleton
-            class="c-holder-list__spinner"
-        />
-    </q-card>
-</template>
-<template v-else-if="!weHaveIndexerSupport && !loading">
+<template v-if="ready && !weHaveIndexerSupport && !loading">
     <MinimumVersionRequired
         class="c-minimum-version-required"
         :required="minimumVersion"
@@ -555,7 +548,7 @@ function calculateDollarValue(row: EvmHolder): string {
     <div class="c-holder-list">
         <!-- Table with data -->
         <q-table
-            v-if="!loading"
+            v-if="ready && !loading"
             v-model:pagination="pagination_model"
             class="c-holder-list__table"
             :rows="holders"

--- a/src/components/Token/HolderList.vue
+++ b/src/components/Token/HolderList.vue
@@ -540,10 +540,8 @@ function calculateDollarValue(row: EvmHolder): string {
 <template>
 <template v-if="!ready">
     <q-card class="c-holder-list__spinner-container">
-        <q-spinner-dots
+        <q-skeleton
             class="c-holder-list__spinner"
-            color="primary"
-            size="40px"
         />
     </q-card>
 </template>
@@ -806,10 +804,17 @@ function calculateDollarValue(row: EvmHolder): string {
     align-self: center;
 }
 
-.c-holder-list__spinner-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100px;
+.c-holder-list {
+    &__spinner-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100px;
+        padding: 15px;
+    }
+    &__spinner {
+        flex-grow: 1;
+    }
 }
+
 </style>


### PR DESCRIPTION
# Fixes #972

## Description
This PR adds a loading spinner while waiting for the indexer to respond to the health request to see if the version is the minimum required. After getting the version, it decides if it can show the table with the data or the text sign explaining the minimum version required is not fulfilled.

## Test scenarios
https://deploy-preview-973--testnet-teloscan.netlify.app/accounts
![image](https://github.com/user-attachments/assets/95cf940f-6a7c-488d-a57b-bc0d44d5c539)

