### PR TITLE
#968 | adding no data sign to Tokens and Blocks tables

### DIFF
--- a/src/components/BlockTable.vue
+++ b/src/components/BlockTable.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n';
 
 import BlockField from 'components/BlockField.vue';
 import DateField from 'components/DateField.vue';
+import EmptyTableSign from 'components/EmptyTableSign';
 import { BlockData } from 'src/types';
 import { ethers } from 'ethers';
 
@@ -226,6 +227,9 @@ onBeforeMount(() => {
     :rows-per-page-options="page_size_options"
     @request="onPaginationChange"
 >
+    <template v-slot:no-data>
+        <EmptyTableSign />
+    </template>
     <!-- header template -->
     <template v-slot:header="props">
         <!--pre>{{ props }}</pre-->

--- a/src/components/Token/TokenList.vue
+++ b/src/components/Token/TokenList.vue
@@ -6,6 +6,7 @@ import DEFAULT_TOKEN_LOGO from 'assets/logo--teloscan.png';
 import TokenGridElement from 'src/components/Token/TokenGridElement';
 import TokenTable from 'src/components/Token/TokenTable';
 import BigDecimal from 'js-big-decimal';
+import EmptyTableSign from 'components/EmptyTableSign';
 import { useChainStore } from 'src/core';
 
 export default {
@@ -16,7 +17,11 @@ export default {
             required: true,
         },
     },
-    components: { TokenGridElement, TokenTable },
+    components: {
+        TokenGridElement,
+        TokenTable,
+        EmptyTableSign,
+    },
     data() {
         return {
             processing: false,
@@ -139,8 +144,7 @@ export default {
 </div>
 <div v-else-if="tokensOfficial.length === 0 && tokens?.length === 0" class="row">
     <div class="col-12 flex items-center justify-center">
-        <q-icon class="fa fa-info-circle" size="md" />
-        <h5 class="text-center  q-mb-xl q-mt-xl q-ml-md"> {{ $t('components.no_balances_found') }}</h5>
+        <EmptyTableSign />
     </div>
 </div>
 <div v-else>

--- a/src/components/Token/TokenTable.vue
+++ b/src/components/Token/TokenTable.vue
@@ -2,11 +2,17 @@
 import AddressField from 'src/components/AddressField';
 import AddToWallet from 'src/components/AddToWallet';
 import ValueField from 'components/ValueField.vue';
+import EmptyTableSign from 'components/EmptyTableSign.vue';
 import { mapActions } from 'vuex';
 
 export default {
     name: 'TokenTable',
-    components: { AddressField, AddToWallet, ValueField },
+    components: {
+        AddressField,
+        AddToWallet,
+        ValueField,
+        EmptyTableSign,
+    },
     props: {
         tokens: {
             type: Array,
@@ -66,6 +72,9 @@ export default {
     :loading="!(rows)"
     :rows-per-page-options="[0]"
 >
+    <template v-slot:no-data>
+        <EmptyTableSign />
+    </template>
 
     <template v-slot:header="props">
         <q-tr :props="props">


### PR DESCRIPTION
# Fixes #968

## Description
This PR adds the same EmptyTableSign component to both, Tokens and Blocks tables.

## Test scenarios
![image](https://github.com/user-attachments/assets/310ca832-a363-4323-bf28-608f68a3932e)
