### PR TITLE
#890 | Fix the rpc and name for first time registering the chain on Metamask

### DIFF
--- a/src/config/chains/telos-evm/index.ts
+++ b/src/config/chains/telos-evm/index.ts
@@ -13,7 +13,7 @@ import { TelosEvmApi } from '@telosnetwork/telosevm-js';
 const config: NetworkConfig =
 {
     'network': 'telos-evm',
-    'display': 'Telos EVM',
+    'display': 'Telos EVM Mainnet',
     'title': 'Telos EVM Explorer',
     'branding': {
         'tab': 'Teloscan',

--- a/src/core/mocks/EVMStore.ts
+++ b/src/core/mocks/EVMStore.ts
@@ -101,7 +101,7 @@ class EVMStore {
 
                 if (chainNotAddedCodes.includes((error as unknown as ExceptionError).code)) {  // 'Chain <hex chain id> hasn't been added'
                     const p:RpcEndpoint = chainSettings.getRPCEndpoint();
-                    const rpcUrl = `${p.protocol}://${p.host}:${p.port}${p.path ?? ''}`;
+                    const rpcUrl = `${p.protocol}://${p.host}`;
                     try {
                         if (!provider.request) {
                             throw new CoreError('core.evm.error_support_provider_request');


### PR DESCRIPTION
# Fixes #890

## Description
The name and RPC link were fixed from `Telos EVM` to `Telos EVM Mainnet` and from `https://rpc.telos.net:433/evm` to `https://rpc.telos.net`

However, with these changes, it is not possible to eliminate the warnings that Metamask displays even using the site's official links that list the known EVM blockchains.

## Test scenarios
- Remove Metamask from browser
- Install a fresh instance of Metamask
- go to this [PR deployment for Mainnet](https://deploy-preview-979--dev-mainnet-teloscan.netlify.app/)
- be sure to be logged out
- try to log in again
- You should see the Metamask warning sign when trying to register the `Telos EVM Mainnet`

![image](https://github.com/user-attachments/assets/1e4450d7-88df-47b3-9f34-331d541a67a4)


## Important
On a fresh installation of Metamask, I tried to register the Telos EVM Mainet blockchain from the official site (https://chainlist.org/chain/40) and I still got the notification that the RFC URL does not match the registration for the blockchain with ID 40
![image](https://github.com/user-attachments/assets/1da6d126-b486-40b1-80f0-e981828dc98f)
