### PR TITLE
#980 | implement chain specific indexer outdated threshold

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,6 +31,7 @@ const checkNetworkHealth = async () => {
     }
     const indexerApi = useChainStore().currentChain.settings.getIndexerApi();
     const chainName = useChainStore().currentChain.settings.getDisplay();
+    const threshold = useChainStore().currentChain.settings.getIndexerSecondsBehindThreshold();
     const theme = $q.dark.isActive ? useChainStore().currentChain.settings.getThemes().dark : useChainStore().currentChain.settings.getThemes().light;
     const health = await indexerApi.get('/v1/health');
     const background = theme?.primary || '#0099FF';
@@ -42,7 +43,7 @@ const checkNetworkHealth = async () => {
         `background: ${background}; color: ${color};`,
     );
 
-    if (health.data?.secondsBehind > 3) {
+    if (health.data?.secondsBehind > threshold) {
         let behindBy = moment(health.data.secondsBehind * 1000).utc().format('HH:mm:ss');
         if (health.data?.secondsBehind > 86400) {
             const behindByHours = Math.round(health.data.secondsBehind / 60 / 60);

--- a/src/config/chains/telos-evm-testnet/index.ts
+++ b/src/config/chains/telos-evm-testnet/index.ts
@@ -301,7 +301,10 @@ export default class TelosEVM extends EVMChainSettings {
     }
 
     getIndexerSecondsBehindThreshold(): number {
-        return config.secondsBehindThreshold || 3;
+        if (isNaN(config.secondsBehindThreshold)) {
+            throw new Error('Invalid secondsBehindThreshold value');
+        }
+        return config.secondsBehindThreshold;
     }
 
     async getUsdPrice(): Promise<number> {

--- a/src/config/chains/telos-evm-testnet/index.ts
+++ b/src/config/chains/telos-evm-testnet/index.ts
@@ -152,6 +152,7 @@ const config: NetworkConfig =
         'gasPrice': false,
         'testnet': true,
     },
+    'secondsBehindThreshold': 5,
     'headerMenuConfig': {
         'chain': 'telos-evm-testnet',
         'entries': [
@@ -297,6 +298,10 @@ export default class TelosEVM extends EVMChainSettings {
 
     getHeaderIndicators(): HeaderIndicators {
         return config.headerIndicators;
+    }
+
+    getIndexerSecondsBehindThreshold(): number {
+        return config.secondsBehindThreshold || 3;
     }
 
     async getUsdPrice(): Promise<number> {

--- a/src/config/chains/telos-evm/index.ts
+++ b/src/config/chains/telos-evm/index.ts
@@ -184,6 +184,7 @@ const config: NetworkConfig =
         'gasPrice': true,
         'testnet': false,
     },
+    'secondsBehindThreshold': 5,
     'headerMenuConfig': {
         'chain': 'telos-evm',
         'entries': [
@@ -350,6 +351,10 @@ export default class TelosEVM extends EVMChainSettings {
 
     getHeaderIndicators(): HeaderIndicators {
         return config.headerIndicators;
+    }
+
+    getIndexerSecondsBehindThreshold(): number {
+        return config.secondsBehindThreshold || 3;
     }
 
     async getUsdPrice(): Promise<number> {

--- a/src/config/chains/telos-evm/index.ts
+++ b/src/config/chains/telos-evm/index.ts
@@ -354,7 +354,10 @@ export default class TelosEVM extends EVMChainSettings {
     }
 
     getIndexerSecondsBehindThreshold(): number {
-        return config.secondsBehindThreshold || 3;
+        if (isNaN(config.secondsBehindThreshold)) {
+            throw new Error('Invalid secondsBehindThreshold value');
+        }
+        return config.secondsBehindThreshold;
     }
 
     async getUsdPrice(): Promise<number> {

--- a/src/config/chains/telos-zkevm-testnet/index.ts
+++ b/src/config/chains/telos-zkevm-testnet/index.ts
@@ -303,7 +303,10 @@ export default class TelosZkEVM extends EVMChainSettings {
     }
 
     getIndexerSecondsBehindThreshold(): number {
-        return config.secondsBehindThreshold || 3;
+        if (isNaN(config.secondsBehindThreshold)) {
+            throw new Error('Invalid secondsBehindThreshold value');
+        }
+        return config.secondsBehindThreshold;
     }
 
     async getUsdPrice(): Promise<number> {

--- a/src/config/chains/telos-zkevm-testnet/index.ts
+++ b/src/config/chains/telos-zkevm-testnet/index.ts
@@ -170,7 +170,7 @@ const config: NetworkConfig =
         'gasPrice': false,
         'testnet': true,
     },
-    'secondsBehindThreshold': 10,
+    'secondsBehindThreshold': 20,
     'headerMenuConfig': {
         'chain': 'telos-zkevm-testnet',
         'entries': [

--- a/src/config/chains/telos-zkevm-testnet/index.ts
+++ b/src/config/chains/telos-zkevm-testnet/index.ts
@@ -170,6 +170,7 @@ const config: NetworkConfig =
         'gasPrice': false,
         'testnet': true,
     },
+    'secondsBehindThreshold': 10,
     'headerMenuConfig': {
         'chain': 'telos-zkevm-testnet',
         'entries': [
@@ -299,6 +300,10 @@ export default class TelosZkEVM extends EVMChainSettings {
 
     getHeaderIndicators(): HeaderIndicators {
         return config.headerIndicators;
+    }
+
+    getIndexerSecondsBehindThreshold(): number {
+        return config.secondsBehindThreshold || 3;
     }
 
     async getUsdPrice(): Promise<number> {

--- a/src/core/mocks/ChainStore.ts
+++ b/src/core/mocks/ChainStore.ts
@@ -50,6 +50,7 @@ export interface TeloscanEVMChainSettings {
     getSocialLinks: () => SocialLink[];
     getFooterLinks: () => FooterLinksConfig;
     getHeaderIndicators: () => HeaderIndicators;
+    getIndexerSecondsBehindThreshold: () => number;
     getHeaderMenuConfig: () => HeaderMenuConfig;
     hasIndexerSupportOver(version:string): boolean;
     // Telos Specific

--- a/src/core/types/NetworkConfig.ts
+++ b/src/core/types/NetworkConfig.ts
@@ -134,6 +134,9 @@ export interface NetworkConfig {
     // Header data indicators
     headerIndicators: HeaderIndicators;
 
+    // How many seconds we need to consider indexer behind
+    secondsBehindThreshold: number;
+
     // Header menu configuration
     headerMenuConfig: {
         chain: string;


### PR DESCRIPTION
# Fixes #980

## Description

This PR adds a new parameter to set the maximum number of seconds to consider the indexer up to date. The new parameter is called `secondsBehindThreshold`
