### PR TITLE
#989 | removing deprecated parameters from contract metadata request

### DIFF
--- a/src/lib/contract/ContractManager.js
+++ b/src/lib/contract/ContractManager.js
@@ -361,7 +361,7 @@ export default class ContractManager {
         this.processing.push(addressLower);
         let contract = null;
         try {
-            let response = await this.indexerApi.get(`/v1/contract/${address}?full=true&includeAbi=true`);
+            let response = await this.indexerApi.get(`/v1/contract/${address}`);
             if(response.data?.success && response.data.results.length > 0){
                 contract = response.data.results[0];
             }


### PR DESCRIPTION
# Fixes #989

## Description
Unused parameters were removed from the contract metadata request

## Test scenarios
- Go to https://deploy-preview-990--dev-mainnet-teloscan.netlify.app/address/0xc96afc666A4195366a46E4ca8C4f10f3C39Ee363
- open dev tools (F12) in Network tab
- filter by "/v1/contract/"
- See no extra parameters in the request