### PR TITLE
#881 | make simple responses no json formated

### DIFF
--- a/src/components/ContractTab/FunctionInterface.vue
+++ b/src/components/ContractTab/FunctionInterface.vue
@@ -424,12 +424,12 @@ export default defineComponent({
         :loading="loading"
         :label="runLabel"
         :disabled="missingInputs"
-        class="run-button q-mb-md"
+        class="run-button q-mb-sm"
         color="primary"
         icon="send"
         @click="run"
     />
-    <p class="text-negative output-container">
+    <p v-if="errorMessage" class="text-negative output-container">
         {{ errorMessage }}
     </p>
     <div v-if="response.length > 0" class="output-container">

--- a/src/components/ContractTab/FunctionOutputViewer.vue
+++ b/src/components/ContractTab/FunctionOutputViewer.vue
@@ -71,7 +71,41 @@ function processOutputResponse(response: OutputValue[], outputs: OutputType[]): 
 // Procesar la respuesta
 const processedResponse = ref<OutputResult>({});
 
+function isBasicTypeResponse(output: OutputResult, indentLevel: number): boolean {
+    let isSimple = true;
+    if (indentLevel > 1) {
+        isSimple = false;
+    } else if (Object.keys(output).length > 1) {
+        isSimple = false;
+    } else {
+        const result = output[Object.keys(output)[0]] as OutputResult;
+        if (typeof result === 'object' && result !== null && typeof result.value === 'undefined') {
+            isSimple = false;
+        }
+    }
+    return isSimple;
+}
+
+function formatBasicOutput(output: OutputResult): string {
+    const data = output[Object.keys(output)[0]] as OutputData;
+    if (data.type === 'address') {
+        return `<a href="/address/${data.value}">${data.value}</a>`;
+    } else if (data.type === 'address[]') {
+        const addresses = (typeof data.value === 'string' ? [data.value] : data.value) as string[];
+        return `[${addresses.map(address => `<a href="/address/${address}">${address}</a>`).join(', ')}]`;
+    } else {
+        if (Array.isArray(data.value)) {
+            return `[${data.value.join(', ')}]`;
+        } else {
+            return `${data.value}`;
+        }
+    }
+}
+
 function formatOutput(output: OutputResult, indentLevel = 1): string {
+    if (isBasicTypeResponse(output, indentLevel)) {
+        return formatBasicOutput(output);
+    }
     const indent = ' '.repeat(indentLevel * 4);
     let json = '{\n';
     let first = true;


### PR DESCRIPTION
# Fixes #881

## Description
When introducing the new `FunctionOutputViewer` component, all responses were formatted as JSON, which was unnecessary for simple-type responses. This issue has been fixed, and simple-type responses are now displayed directly without using JSON, resulting in a more compact display.

## Test scenarios
https://deploy-preview-994--testnet-teloscan.netlify.app/address/0x08B10679B2Cf7A244293fD670CDf0EF5F2982588?tab=contract&subtab=read

![image](https://github.com/user-attachments/assets/52956632-96a4-424e-a66e-ca8010f3daa8)
