### PR TITLE
#622 | Move Safari navbar styles under safari specific class

### DIFF
--- a/src/components/header/AppHeaderBottomBar.vue
+++ b/src/components/header/AppHeaderBottomBar.vue
@@ -94,7 +94,7 @@ const settings = computed(() => useChainStore().currentChain.settings);
     left: 0;
     right: 0;
     height: var(--bottom-bar-height);
-    min-height: 52px; /* Add minimum height for Safari */
+    min-height: var(--bottom-bar-height); /* Add minimum height for Safari */
 
     background: var(--background-color);
     border-bottom: 1px solid var(--border-color);

--- a/src/components/header/AppHeaderLinks.vue
+++ b/src/components/header/AppHeaderLinks.vue
@@ -286,6 +286,18 @@ function showEntry(entry: HeaderMenuEntry): boolean {
 </template>
 
 <style lang="scss">
+
+.is-safari {
+    // Safari-specific CSS
+    .c-header-links__submenu-ul {
+        min-width: 230px !important;
+    }
+
+    .c-header-links__menu-li:nth-child(3) .c-header-links__submenu-ul {
+        min-width: 320px !important;
+    }
+}
+
 .c-header-links {
     $this: &;
 

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -101,16 +101,6 @@ a {
     max-width: 100%;
 }
 
-/* Fix for Safari navbar submenu display */
-.c-header-links__submenu-ul {
-  min-width: 230px !important; /* Wide enough for most menu items */
-}
-
-/* Extra width for Developer menu (which has longer items) */
-.c-header-links__menu-li:nth-child(3) .c-header-links__submenu-ul {
-  min-width: 320px !important; /* Extra wide for this specific menu */
-}
-
 .q-tab--inactive {
     opacity: unset;
 }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -96,6 +96,12 @@ onMounted(() => {
     initMultichain($router, $route);
 });
 
+// tries to detect if the browser is Safari and adds a class to the body
+if (navigator.userAgent.includes('Safari') && !navigator.userAgent.includes('Chrome')) {
+    document.body.classList.add('is-safari');
+}
+
+
 </script>
 
 <template>


### PR DESCRIPTION
# Fixes #622

## Description
This PR moves all Safari-specific styles under the .is-safari class once detected by javascript code.

This prevents those specific styles from affecting the website running on other browsers.

## Test scenarios
- Test the navbar menus on Chrome or Firefox
  - See no changes
- Test the nabvar menues on Safari
  - See the specific style changes being applied.


